### PR TITLE
turbojpeg: Filter out scaling factors that have 0 as the denominator

### DIFF
--- a/imageio-openjpeg/pom.xml
+++ b/imageio-openjpeg/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.digitalcollections.imageio</groupId>
     <artifactId>imageio-jnr</artifactId>
-    <version>0.2.6</version>
+    <version>0.2.7-SNAPSHOT</version>
   </parent>
   <artifactId>imageio-openjpeg</artifactId>
   <name>MDZ/Bayerische Staatsbibliothek :: ImageIO :: OpenJPEG/JPEG2000 plugin</name>

--- a/imageio-turbojpeg/pom.xml
+++ b/imageio-turbojpeg/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.digitalcollections.imageio</groupId>
     <artifactId>imageio-jnr</artifactId>
-    <version>0.2.6</version>
+    <version>0.2.7-SNAPSHOT</version>
   </parent>
   <artifactId>imageio-turbojpeg</artifactId>
   <name>MDZ/Bayerische Staatsbibliothek :: ImageIO :: TurboJPEG plugin</name>

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/Info.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/Info.java
@@ -40,6 +40,7 @@ public class Info {
     this.subsampling = subsampling;
     // The available sizes are determined from the list of scaling factors.
     this.availableSizes = Arrays.stream(factors)
+        .filter(f -> f.denom.get() > 0)
         .sorted(Comparator.comparing(f -> -getScaled(width, f.num.get(), f.denom.get())))
         .map(f -> new Dimension(getScaled(width, f.num.get(), f.denom.get()),
                                 getScaled(height, f.num.get(), f.denom.get())))

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections.imageio</groupId>
   <artifactId>imageio-jnr</artifactId>
-  <version>0.2.6</version>
+  <version>0.2.7-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>MDZ/Bayerische Staatsbibliothek :: ImageIO</name>
   <description>Parent for ImageIO-JNR components.</description>


### PR DESCRIPTION
With newer turbojpeg versions (tested with 2.0.) it seems that we sometimes get scaling factors that have a denominator of `0`, which will cause `DivisionByZero` errors while creating `Info` objects for images.
This PR will filter out all factors with `0` as the denominator to prevent this.