### PR TITLE
JUnit 5.4

### DIFF
--- a/imageio-openjpeg/pom.xml
+++ b/imageio-openjpeg/pom.xml
@@ -29,12 +29,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/imageio-turbojpeg/pom.xml
+++ b/imageio-turbojpeg/pom.xml
@@ -38,12 +38,7 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <version.assertj>3.8.0</version.assertj>
     <version.jnr-ffi>2.1.7</version.jnr-ffi>
     <version.slf4j>1.8.0-beta2</version.slf4j>
-    <version.junit-jupiter>5.3.2</version.junit-jupiter>
+    <version.junit-jupiter>5.4.0</version.junit-jupiter>
 
     <!-- plugins -->
     <version.jacoco-maven-plugin>0.8.3</version.jacoco-maven-plugin>
@@ -84,12 +84,7 @@
       </dependency>
       <dependency>
         <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>${version.junit-jupiter}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
+        <artifactId>junit-jupiter</artifactId>
         <version>${version.junit-jupiter}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This PR updates `junit-jupiter` to latest 5.4 version.

With the 5.4 series the `junit-jupiter` meta package can be used instead of `junit-jupiter-api` and `junit-jupiter-engine`.