### PR TITLE
CI: remove Oracle JDKs and update Ubuntu distribution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: java
+dist: xenial
 jdk:
 - openjdk8
-- oraclejdk8
-- oraclejdk9
 - openjdk11
 addons:
   apt:

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ libraries are installed on the target system. However, thanks to JNR-FFI, no
 compiler is neccessary, the plugins will directly use the installed native
 libraries and you can install them directly from Maven Central.
 
-Please note that the plugins need at least Java 8.
+Please note that the plugins need at least Java 8 and Ubuntu 16.04.
 
 ## Currently available plugins
 
 |       Module      |   Format  |      Backing native library         |             Required version               | JavaDoc
 | ----------------- | --------- | ----------------------------------- | ------------------------------------------ | ---
 | imageio-openjpeg  | JPEG2000  | [OpenJPEG](http://www.openjpeg.org) | \>= 2.0 (>=2.3 recommended for performance) | [![Javadocs](http://javadoc.io/badge/de.digitalcollections.imageio/imageio-openjpeg.svg)](http://javadoc.io/doc/de.digitalcollections.imageio/imageio-openjpeg)
-| imageio-turbojpeg |    JPEG   | [TurboJPEG](https://libjpeg-turbo.org/About/TurboJPEG) | \>= 1.0               | [![Javadocs](http://javadoc.io/badge/de.digitalcollections.imageio/imageio-turbojpeg.svg)](http://javadoc.io/doc/de.digitalcollections.imageio/imageio-turbojpeg)
+| imageio-turbojpeg |    JPEG   | [TurboJPEG](https://libjpeg-turbo.org/About/TurboJPEG) | \>= 1.4               | [![Javadocs](http://javadoc.io/badge/de.digitalcollections.imageio/imageio-turbojpeg.svg)](http://javadoc.io/doc/de.digitalcollections.imageio/imageio-turbojpeg)
 
 
 ## Installation


### PR DESCRIPTION
In order to support latest changes that were introduced in 9e78e252908ccefbc01fdce36c092c768d280269 and 77724abee739b2663b718b434fc54cda4b9545e3, it is necessary to use a more recent version of `libjpeg-turbo` (at least version 1.4) in combination with JDK 8.

Thus, this PR updates the Ubuntu version for Travis CI from 14.04 to 16.04. Furthermore, all Oracle JDKs are completely removed. We rely on OpenJDK now.