### PR TITLE
turbojpeg: Fix grayscale encoding bug

### DIFF
--- a/imageio-openjpeg/pom.xml
+++ b/imageio-openjpeg/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.digitalcollections.imageio</groupId>
     <artifactId>imageio-jnr</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2-SNAPSHOT</version>
   </parent>
   <artifactId>imageio-openjpeg</artifactId>
   <name>MDZ/Bayerische Staatsbibliothek :: ImageIO :: OpenJPEG/JPEG2000 plugin</name>

--- a/imageio-turbojpeg/pom.xml
+++ b/imageio-turbojpeg/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>de.digitalcollections.imageio</groupId>
     <artifactId>imageio-jnr</artifactId>
-    <version>0.3.1</version>
+    <version>0.3.2-SNAPSHOT</version>
   </parent>
   <artifactId>imageio-turbojpeg</artifactId>
   <name>MDZ/Bayerische Staatsbibliothek :: ImageIO :: TurboJPEG plugin</name>

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/TurboJpeg.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/TurboJpeg.java
@@ -161,7 +161,7 @@ public class TurboJpeg {
 
       // Wrap source image data buffer with ByteBuffer to pass it over the ABI
       ByteBuffer inBuf;
-      if (img.getNumBands() == 1) {
+      if (img.getNumBands() == 1 && img.getSampleModel().getSampleSize(0) == 1) {
         // For binary images, we need to convert our (0, 1) binary values into (0, 255) greyscale values
         int[] buf = new int[img.getWidth() * img.getHeight()];
         img.getPixels(0, 0, img.getWidth(), img.getHeight(), buf);

--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
@@ -241,6 +241,5 @@ class TurboJpegImageReaderTest {
     BufferedImage img = reader.read(0, param);
     assertThat(img.getWidth()).isEqualTo(1);
     assertThat(img.getHeight()).isEqualTo(1);
-
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>de.digitalcollections.imageio</groupId>
   <artifactId>imageio-jnr</artifactId>
-  <version>0.3.1</version>
+  <version>0.3.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>MDZ/Bayerische Staatsbibliothek :: ImageIO</name>
   <description>Parent for ImageIO-JNR components.</description>


### PR DESCRIPTION
Previously, grayscale input images would be encoded as all-white images.