### PR TITLE
Handle 16bit images

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image_comp.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image_comp.java
@@ -17,7 +17,7 @@ public class opj_image_comp extends Struct {
   /** y component offset compared to the whole image */
   Unsigned32 y0 = new Unsigned32();
   /** precision */
-  Unsigned32 prec = new Unsigned32();
+  public Unsigned32 prec = new Unsigned32();
   /** image depth in bits */
   Unsigned32 bpp = new Unsigned32();
   /** signed (1) / unsigned (0) */

--- a/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderTest.java
+++ b/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderTest.java
@@ -100,4 +100,19 @@ class OpenJp2ImageReaderTest {
 
     assertThat(rgbImg.getRGB(256, 256)).isNotEqualTo(bwImg.getRGB(256, 256));
   }
+
+  @Test
+  public void testCanRead16BitImage() throws IOException {
+    // Image is licensed under CC BY-NC-SA 4.0
+    OpenJp2ImageReader reader = getReader("bpp_16.jp2");
+    BufferedImage img = reader.read(0, null);
+
+    assertThat(img.getType()).isEqualTo(BufferedImage.TYPE_3BYTE_BGR);
+
+    // Pixel at 2,0 should have following color information: 49 (R), 47 (G), 50 (B)
+    // Underlying image has color information encoded as BGR
+    assertThat(img.getRaster().getDataBuffer().getElem(6)).isEqualTo(50); // B
+    assertThat(img.getRaster().getDataBuffer().getElem(7)).isEqualTo(47); // G
+    assertThat(img.getRaster().getDataBuffer().getElem(8)).isEqualTo(49); // R
+  }
 }


### PR DESCRIPTION
This PR fixes a bug that occurs, when the input image has 16bit color depth. In these cases, the output image just contained random noise.

This PR fixes that bug and handles the conversion from 16bit to 8bit correctly.