### PR TITLE
openjpeg: Take embedded ICC color profiles into account and convert accordingly

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image.java
@@ -21,9 +21,9 @@ public class opj_image extends Struct {
   /** image components */
   public StructRef<opj_image_comp> comps = new StructRef<>(opj_image_comp.class);
   /** 'restricted' ICC profile */
-  Pointer icc_profile_buf = new Pointer();
+  public Pointer icc_profile_buf = new Pointer();
   /** size of ICC profile */
-  Unsigned32 icc_profile_len = new Unsigned32();
+  public Unsigned32 icc_profile_len = new Unsigned32();
 
   public opj_image(Runtime runtime) {
     super(runtime);

--- a/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderTest.java
+++ b/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderTest.java
@@ -102,17 +102,17 @@ class OpenJp2ImageReaderTest {
   }
 
   @Test
-  public void testCanRead16BitImage() throws IOException {
+  public void testCanRead16BitImageWithColorspace() throws IOException {
     // Image is licensed under CC BY-NC-SA 4.0
     OpenJp2ImageReader reader = getReader("bpp_16.jp2");
     BufferedImage img = reader.read(0, null);
 
     assertThat(img.getType()).isEqualTo(BufferedImage.TYPE_3BYTE_BGR);
 
-    // Pixel at 2,0 should have following color information: 49 (R), 47 (G), 50 (B)
+    // Pixel at 2,0 should have following color information: 46 (R), 43 (G), 47 (B)
     // Underlying image has color information encoded as BGR
-    assertThat(img.getRaster().getDataBuffer().getElem(6)).isEqualTo(50); // B
-    assertThat(img.getRaster().getDataBuffer().getElem(7)).isEqualTo(47); // G
-    assertThat(img.getRaster().getDataBuffer().getElem(8)).isEqualTo(49); // R
+    assertThat(img.getRaster().getDataBuffer().getElem(6)).isEqualTo(47); // B
+    assertThat(img.getRaster().getDataBuffer().getElem(7)).isEqualTo(43); // G
+    assertThat(img.getRaster().getDataBuffer().getElem(8)).isEqualTo(46); // R
   }
 }


### PR DESCRIPTION
Previously:

![](https://i.imgur.com/F2W1fHb.jpg)

Now:

![](https://i.imgur.com/p7rTtMu.jpg)