### PR TITLE
openjpeg: Fix potential memory leak when setting new input stream on existing reader

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/InStreamWrapper.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/InStreamWrapper.java
@@ -3,7 +3,6 @@ package de.digitalcollections.openjpeg;
 import de.digitalcollections.openjpeg.lib.callbacks.opj_stream_read_fn;
 import de.digitalcollections.openjpeg.lib.callbacks.opj_stream_skip_fn;
 import de.digitalcollections.openjpeg.lib.libopenjp2;
-import java.io.IOException;
 import jnr.ffi.Pointer;
 
 public abstract class InStreamWrapper {
@@ -36,7 +35,7 @@ public abstract class InStreamWrapper {
 
   protected abstract long skip(long numBytes, Pointer userData);
 
-  public void close() throws IOException {
+  public void close() {
     lib.opj_stream_destroy(this.stream);
     this.stream = null;
   }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReader.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReader.java
@@ -46,6 +46,9 @@ public class OpenJp2ImageReader extends ImageReader {
     } else {
       throw new IllegalArgumentException("Bad input.");
     }
+    if (this.streamWrapper != null) {
+      this.streamWrapper.close();
+    }
     this.streamWrapper = new ImageInputStreamWrapper(stream, lib);
   }
 
@@ -208,12 +211,8 @@ public class OpenJp2ImageReader extends ImageReader {
   @Override
   public void dispose() {
     if (this.streamWrapper != null) {
-      try {
-        this.streamWrapper.close();
-        this.streamWrapper = null;
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+      this.streamWrapper.close();
+      this.streamWrapper = null;
     }
     this.info = null;
   }


### PR DESCRIPTION
If you used `reader.setInput(...)`, it would leak the memory of the previous wrapped `ImageInputStream`, leading to 1MiB of inaccessible off-heap memory.