### PR TITLE
openjpeg: Don't convert color space (too big a performance hit)

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/OpenJpeg.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/OpenJpeg.java
@@ -11,15 +11,10 @@ import de.digitalcollections.openjpeg.lib.structs.opj_image;
 import de.digitalcollections.openjpeg.lib.structs.opj_image_comp;
 import de.digitalcollections.openjpeg.lib.structs.opj_image_comptparm;
 import java.awt.Rectangle;
-import java.awt.color.ICC_ColorSpace;
-import java.awt.color.ICC_Profile;
 import java.awt.image.BufferedImage;
-import java.awt.image.ColorConvertOp;
 import java.awt.image.DataBufferByte;
 import java.awt.image.PixelInterleavedSampleModel;
 import java.awt.image.Raster;
-import java.awt.image.RasterOp;
-import java.awt.image.WritableRaster;
 import java.io.IOException;
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.Pointer;
@@ -216,19 +211,6 @@ public class OpenJpeg {
       } else {
         throw new IOException(String.format("Unsupported number of components: %d", numcomps));
       }
-
-      // Convert color space, if present
-      if (img.icc_profile_len.intValue() > 0) {
-        byte[] iccData = new byte[img.icc_profile_len.intValue()];
-        img.icc_profile_buf.get().get(0, iccData, 0, iccData.length);
-        ICC_Profile iccProfile = ICC_Profile.getInstance(iccData);
-        ICC_ColorSpace intendedCS = new ICC_ColorSpace(iccProfile);
-        RasterOp convert = new ColorConvertOp(intendedCS, bufImg.getColorModel().getColorSpace(), null);
-        WritableRaster dest = bufImg.getRaster()
-            .createWritableChild(0, 0, bufImg.getWidth(), bufImg.getHeight(), 0, 0, null);
-        convert.filter(bufImg.getRaster(), dest);
-      }
-
       return bufImg;
     } finally {
       if (img != null) {

--- a/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderTest.java
+++ b/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class OpenJp2ImageReaderTest {
+
   @Test
   public void testReaderIsRegistered() {
     assertThat(Lists.newArrayList(ImageIO.getImageReadersBySuffix("jp2"))).isNotEmpty();
@@ -99,20 +100,5 @@ class OpenJp2ImageReaderTest {
     BufferedImage bwImg = reader.read(0, null);
 
     assertThat(rgbImg.getRGB(256, 256)).isNotEqualTo(bwImg.getRGB(256, 256));
-  }
-
-  @Test
-  public void testCanRead16BitImageWithColorspace() throws IOException {
-    // Image is licensed under CC BY-NC-SA 4.0
-    OpenJp2ImageReader reader = getReader("bpp_16.jp2");
-    BufferedImage img = reader.read(0, null);
-
-    assertThat(img.getType()).isEqualTo(BufferedImage.TYPE_3BYTE_BGR);
-
-    // Pixel at 2,0 should have following color information: 46 (R), 43 (G), 47 (B)
-    // Underlying image has color information encoded as BGR
-    assertThat(img.getRaster().getDataBuffer().getElem(6)).isEqualTo(47); // B
-    assertThat(img.getRaster().getDataBuffer().getElem(7)).isEqualTo(43); // G
-    assertThat(img.getRaster().getDataBuffer().getElem(8)).isEqualTo(46); // R
   }
 }


### PR DESCRIPTION
This should be properly implemented another time by carrying over the ICC data to the ImageIO metadata.