### PR TITLE
openjpeg: Add support for direct file access (thanks @renevanderark!)

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/libopenjp2.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/libopenjp2.java
@@ -32,6 +32,7 @@ public interface libopenjp2 {
   String opj_version();
 
   /* Stream functions */
+  Pointer opj_stream_create_default_file_stream(String filename, boolean isReadStream);
   Pointer opj_stream_create(@size_t long bufSize, boolean isInput);
   void opj_stream_set_read_function(Pointer stream, opj_stream_read_fn read_fn);
   void opj_stream_set_write_function(Pointer stream, opj_stream_write_fn write_fn);


### PR DESCRIPTION
@renevanderark did some performance testing of the library and noticed a performance gap between the JNR-code and his previous JNI-based approach. One difference in the access path was that he did not use wrapped bytestreams, but relied on the `opj_stream_create_default_file_stream` API to access the source images.

This PR adds two new overloads for `OpenJpeg#getInfo` and `OpenJpeg#decode` that take a `Path` argument instead of an `InputStreamWrapper` to expose this access path to the Java API.

This is mostly intended for users who use the library through the `OpenJpeg` interface and not the ImageIO APIs.

Thanks @renevanderark!