### PR TITLE
Add auto-formatting via google style

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/InStreamWrapper.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/InStreamWrapper.java
@@ -9,8 +9,10 @@ public abstract class InStreamWrapper {
   private Pointer stream;
   private libopenjp2 lib;
 
-  // NOTE: We cannot use method references, since their evaluation creates a temporary instance of the functional
-  // interface. That is, if we set the callbacks in the constructor as we should, the temporary instances would get
+  // NOTE: We cannot use method references, since their evaluation creates a temporary instance of
+  // the functional
+  // interface. That is, if we set the callbacks in the constructor as we should, the temporary
+  // instances would get
   // garbage-collected at some point, which would lead to bad things.
   private opj_stream_read_fn readCallback;
   private opj_stream_skip_fn skipCallback;
@@ -22,7 +24,8 @@ public abstract class InStreamWrapper {
     this.readCallback = this::read;
     lib.opj_stream_set_read_function(stream, readCallback);
     lib.opj_stream_set_skip_function(stream, skipCallback);
-    // NOTE: This should not be 0 and >= the size of the actual file. However, if we set it to the maximum value,
+    // NOTE: This should not be 0 and >= the size of the actual file. However, if we set it to the
+    // maximum value,
     //       it works with streams of any length without any drawbacks (as far as I could tell...)
     lib.opj_stream_set_user_data_length(stream, (long) Math.pow(2, 32));
   }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/Info.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/Info.java
@@ -7,9 +7,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-/**
- * Information about an image from OpenJP2.
- */
+/** Information about an image from OpenJP2. */
 public class Info {
   private int numComponents;
   private int numResolutions;
@@ -94,30 +92,25 @@ public class Info {
     return numTilesX + numTilesY;
   }
 
-  /**
-   * Get the scale factors that are available for decoding.
-   */
+  /** Get the scale factors that are available for decoding. */
   public double[] getScaleFactors() {
-    return IntStream.range(0, this.numResolutions)
-        .mapToDouble(n -> Math.pow(2, n))
-        .toArray();
+    return IntStream.range(0, this.numResolutions).mapToDouble(n -> Math.pow(2, n)).toArray();
   }
 
-  /**
-   * Get the image sizes that are available for decoding.
-   */
+  /** Get the image sizes that are available for decoding. */
   public List<Dimension> getAvailableImageSizes() {
     return Arrays.stream(getScaleFactors())
-        .mapToObj(factor -> new Dimension((int) (this.width / factor), (int) (this.height / factor)))
+        .mapToObj(
+            factor -> new Dimension((int) (this.width / factor), (int) (this.height / factor)))
         .collect(Collectors.toList());
   }
 
-  /**
-   * Get the tile sizes that are available for decoding.
-   */
+  /** Get the tile sizes that are available for decoding. */
   public List<Dimension> getAvailableTileSizes() {
     return Arrays.stream(getScaleFactors())
-        .mapToObj(factor -> new Dimension((int) (this.tileWidth / factor), (int) (this.tileHeight / factor)))
+        .mapToObj(
+            factor ->
+                new Dimension((int) (this.tileWidth / factor), (int) (this.tileHeight / factor)))
         .collect(Collectors.toList());
   }
 }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/OutStreamWrapper.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/OutStreamWrapper.java
@@ -11,8 +11,10 @@ public abstract class OutStreamWrapper {
   private libopenjp2 lib;
   private Pointer stream;
 
-  // NOTE: We cannot use method references, since their evaluation creates a temporary instance of the functional
-  // interface. That is, if we set the callbacks in the constructor without storing the method references, the
+  // NOTE: We cannot use method references, since their evaluation creates a temporary instance of
+  // the functional
+  // interface. That is, if we set the callbacks in the constructor without storing the method
+  // references, the
   // temporary instances would get garbage-collected at some point, which would lead to bad things.
   private opj_stream_write_fn writeCallback;
   private opj_stream_skip_fn skipCallback;
@@ -27,7 +29,8 @@ public abstract class OutStreamWrapper {
     lib.opj_stream_set_write_function(stream, writeCallback);
     lib.opj_stream_set_skip_function(stream, skipCallback);
     lib.opj_stream_set_seek_function(stream, seekCallback);
-    // NOTE: This should not be 0 and >= the size of the actual file. However, if we set it to the maximum value,
+    // NOTE: This should not be 0 and >= the size of the actual file. However, if we set it to the
+    // maximum value,
     //       it works with streams of any length without any drawbacks (as far as I could tell...)
     lib.opj_stream_set_user_data_length(stream, (long) Math.pow(2, 32));
   }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReader.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReader.java
@@ -17,7 +17,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * ImageReader for JPEG2000 images, based on the openjp2 library from the OpenJPEG project, accessed via JNR-FFI.
+ * ImageReader for JPEG2000 images, based on the openjp2 library from the OpenJPEG project, accessed
+ * via JNR-FFI.
  */
 public class OpenJp2ImageReader extends ImageReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenJp2ImageReader.class);
@@ -41,7 +42,7 @@ public class OpenJp2ImageReader extends ImageReader {
     if (input == null) {
       return;
     }
-    if (input instanceof  ImageInputStream) {
+    if (input instanceof ImageInputStream) {
       stream = (ImageInputStream) input;
     } else {
       throw new IllegalArgumentException("Bad input.");
@@ -55,7 +56,7 @@ public class OpenJp2ImageReader extends ImageReader {
   /**
    * Corresponds to the number of resolutions in the image.
    *
-   * Image 0 has the native resolution, all following indices are 1/2^idx times smaller.
+   * <p>Image 0 has the native resolution, all following indices are 1/2^idx times smaller.
    */
   @Override
   public int getNumImages(boolean allowSearch) throws IOException {
@@ -86,18 +87,14 @@ public class OpenJp2ImageReader extends ImageReader {
     return (int) (size / Math.pow(2, (double) imageIndex));
   }
 
-  /**
-   * Get the width of the given resolution of the image.
-   */
+  /** Get the width of the given resolution of the image. */
   @Override
   public int getWidth(int imageIndex) throws IOException {
     checkIndex(imageIndex);
     return adjustSize(info.getNativeSize().width, imageIndex);
   }
 
-  /**
-   * Get the height of the given resolution of the image.
-   */
+  /** Get the height of the given resolution of the image. */
   @Override
   public int getHeight(int imageIndex) throws IOException {
     checkIndex(imageIndex);
@@ -108,15 +105,17 @@ public class OpenJp2ImageReader extends ImageReader {
   public Iterator<ImageTypeSpecifier> getImageTypes(int imageIndex) throws IOException {
     checkIndex(imageIndex);
     // TODO: Support grayscale?
-    return Collections.singletonList(ImageTypeSpecifier.createFromBufferedImageType(BufferedImage.TYPE_3BYTE_BGR))
-                      .iterator();
+    return Collections.singletonList(
+            ImageTypeSpecifier.createFromBufferedImageType(BufferedImage.TYPE_3BYTE_BGR))
+        .iterator();
   }
 
   private Rectangle adjustRegion(int imageIndex, Rectangle sourceRegion) throws IOException {
     if (sourceRegion == null) {
       return null;
     }
-    if (sourceRegion.x == 0 && sourceRegion.y == 0
+    if (sourceRegion.x == 0
+        && sourceRegion.y == 0
         && sourceRegion.width == getWidth(imageIndex)
         && sourceRegion.height == getHeight(imageIndex)) {
       return null;
@@ -129,9 +128,7 @@ public class OpenJp2ImageReader extends ImageReader {
         (int) Math.ceil(scaleFactor * sourceRegion.height));
   }
 
-  /**
-   * Read the image in the given resolution.
-   */
+  /** Read the image in the given resolution. */
   @Override
   public BufferedImage read(int imageIndex, ImageReadParam param) throws IOException {
     checkIndex(imageIndex);
@@ -185,12 +182,11 @@ public class OpenJp2ImageReader extends ImageReader {
     int yOffset = getTileGridYOffset(imageIndex);
     int tileWidth = getTileWidth(imageIndex);
     int tileHeight = getTileHeight(imageIndex);
-    Rectangle region = new Rectangle(
-        xOffset + tileX * tileWidth,
-        yOffset + tileY * tileHeight,
-        tileWidth,
-        tileHeight);
-    if (region.x + region.width > getWidth(imageIndex) || region.y + region.height > getHeight(imageIndex)) {
+    Rectangle region =
+        new Rectangle(
+            xOffset + tileX * tileWidth, yOffset + tileY * tileHeight, tileWidth, tileHeight);
+    if (region.x + region.width > getWidth(imageIndex)
+        || region.y + region.height > getHeight(imageIndex)) {
       throw new IllegalArgumentException("Tile indices out of bounds.");
     }
     ImageReadParam param = getDefaultReadParam();

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderSpi.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderSpi.java
@@ -15,28 +15,44 @@ import org.slf4j.LoggerFactory;
 public class OpenJp2ImageReaderSpi extends ImageReaderSpi {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenJp2ImageReaderSpi.class);
-  private static byte[] HEADER_MAGIC = new byte[]{0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50,
-                                                  0x20, 0x20, 0x0d, 0x0a, (byte) 0x87, 0x0a};
-  private static final String vendorName = "Münchener Digitalisierungszentrum/Digitale Bibliothek, Bayerische Staatsbibliothek";
+  private static byte[] HEADER_MAGIC =
+      new byte[] {0x00, 0x00, 0x00, 0x0c, 0x6a, 0x50, 0x20, 0x20, 0x0d, 0x0a, (byte) 0x87, 0x0a};
+  private static final String vendorName =
+      "Münchener Digitalisierungszentrum/Digitale Bibliothek, Bayerische Staatsbibliothek";
   private static final String version = "0.2.6";
-  private static final String readerClassName = "de.digitalcollections.openjpeg.imageio.OpenJp2ImageReader";
+  private static final String readerClassName =
+      "de.digitalcollections.openjpeg.imageio.OpenJp2ImageReader";
   private static final String[] names = {"jpeg2000"};
   private static final String[] suffixes = {"jp2"};
   private static final String[] MIMETypes = {"image/jp2"};
-  private static final String[] writerSpiNames = {"de.digitalcollections.openjpeg.imageio.OpenJp2ImageWriterSpi"};
+  private static final String[] writerSpiNames = {
+    "de.digitalcollections.openjpeg.imageio.OpenJp2ImageWriterSpi"
+  };
   private static final Class[] inputTypes = {ImageInputStream.class};
 
   private OpenJpeg lib;
 
-  /**
-   * Construct the SPI, boilerplate.
-   */
+  /** Construct the SPI, boilerplate. */
   public OpenJp2ImageReaderSpi() {
-    super(vendorName, version, names, suffixes, MIMETypes, readerClassName, inputTypes, writerSpiNames,
-            false, null, null,
-            null, null, false,
-            null, null, null,
-            null);
+    super(
+        vendorName,
+        version,
+        names,
+        suffixes,
+        MIMETypes,
+        readerClassName,
+        inputTypes,
+        writerSpiNames,
+        false,
+        null,
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        null);
   }
 
   private void loadLibrary() throws IOException {

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageWriteParam.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageWriteParam.java
@@ -7,13 +7,15 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 import javax.imageio.ImageWriteParam;
 
-/**
- * Parameters for encoding JPEG2000 images
- */
+/** Parameters for encoding JPEG2000 images */
 public class OpenJp2ImageWriteParam extends ImageWriteParam {
 
   public enum ProgressionOrder {
-    LRCP(0), RLCP(1), RPCL(2), PCRL(3), CPRL(4);
+    LRCP(0),
+    RLCP(1),
+    RPCL(2),
+    PCRL(3),
+    CPRL(4);
 
     private int val;
 
@@ -22,28 +24,26 @@ public class OpenJp2ImageWriteParam extends ImageWriteParam {
     }
 
     PROG_ORDER toNative() {
-      return Arrays.stream(PROG_ORDER.values())
-              .filter(v -> v.value == this.val)
-              .findFirst().get();
+      return Arrays.stream(PROG_ORDER.values()).filter(v -> v.value == this.val).findFirst().get();
     }
   }
 
   public static String COMPRESS_TYPE_LOSSY = "lossy";
   public static String COMPRESS_TYPE_LOSSLESS = "lossless";
 
-  /** Use irreversible wavelet compression (= lossy) **/
+  /** Use irreversible wavelet compression (= lossy) * */
   boolean compressLossy = false;
 
-  /** Write SOP marker before each packet **/
+  /** Write SOP marker before each packet * */
   boolean writeSOPMarkers = false;
 
-  /** Write EPH marker after each header packet **/
+  /** Write EPH marker after each header packet * */
   boolean writeEPHMarkers = false;
 
-  /** Number of resolutions to encode **/
+  /** Number of resolutions to encode * */
   int numResolutions = 6;
 
-  /** Progession order. Defaults to LRCP. **/
+  /** Progession order. Defaults to LRCP. * */
   ProgressionOrder progOrder = ProgressionOrder.LRCP;
 
   protected opj_cparameters toNativeParams(OpenJpeg lib) {
@@ -106,12 +106,10 @@ public class OpenJp2ImageWriteParam extends ImageWriteParam {
 
   @Override
   public String[] getCompressionTypes() {
-    return new String[]{"lossless", "lossy"};
+    return new String[] {"lossless", "lossy"};
   }
 
-  /**
-   * Set the compression type. Must be 'lossless' (default) or 'lossy'.
-   */
+  /** Set the compression type. Must be 'lossless' (default) or 'lossy'. */
   @Override
   public void setCompressionType(String compressionType) {
     if (Stream.of(COMPRESS_TYPE_LOSSLESS, COMPRESS_TYPE_LOSSY).noneMatch(compressionType::equals)) {
@@ -147,6 +145,7 @@ public class OpenJp2ImageWriteParam extends ImageWriteParam {
 
   /**
    * Write SOP markers after each packet.
+   *
    * @param writeSOPMarkers flag if sop markers should be written
    */
   public void setWriteSOPMarkers(boolean writeSOPMarkers) {
@@ -159,6 +158,7 @@ public class OpenJp2ImageWriteParam extends ImageWriteParam {
 
   /**
    * Write EPH marker after each header packet.
+   *
    * @param writeEPHMarkers flag if eph markers should be written
    */
   public void setWriteEPHMarkers(boolean writeEPHMarkers) {
@@ -166,10 +166,11 @@ public class OpenJp2ImageWriteParam extends ImageWriteParam {
   }
 
   /**
-   * Set the compression quality. Automatically switches compression type to lossy.
-   * {@link ImageWriteParam#setCompressionType} must have been set to {@link ImageWriteParam#MODE_EXPLICIT}.
+   * Set the compression quality. Automatically switches compression type to lossy. {@link
+   * ImageWriteParam#setCompressionType} must have been set to {@link
+   * ImageWriteParam#MODE_EXPLICIT}.
    *
-   * Quality must be between 0.0 (worst) and 1.0 (best).
+   * <p>Quality must be between 0.0 (worst) and 1.0 (best).
    */
   @Override
   public void setCompressionQuality(float quality) {
@@ -184,7 +185,8 @@ public class OpenJp2ImageWriteParam extends ImageWriteParam {
   /**
    * Set the number of resolutions to encode in the output image.
    *
-   * Each resolution will be 2^num times smaller than the native resolution.
+   * <p>Each resolution will be 2^num times smaller than the native resolution.
+   *
    * @param numResolutions the num resolutions
    */
   public void setNumResolutions(int numResolutions) {
@@ -197,6 +199,7 @@ public class OpenJp2ImageWriteParam extends ImageWriteParam {
 
   /**
    * Set the progression order of the encoded image.
+   *
    * @param progOrder the progression order
    */
   public void setProgressionOrder(ProgressionOrder progOrder) {

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageWriter.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageWriter.java
@@ -15,7 +15,8 @@ import javax.imageio.spi.ImageWriterSpi;
 import javax.imageio.stream.ImageOutputStream;
 
 /**
- * ImageWriter for JPEG2000 images, based on the openjp2 library from the OpenJPEG project, accessed via JNR-FFI.
+ * ImageWriter for JPEG2000 images, based on the openjp2 library from the OpenJPEG project, accessed
+ * via JNR-FFI.
  */
 public class OpenJp2ImageWriter extends ImageWriter {
   private OpenJpeg lib;
@@ -64,12 +65,14 @@ public class OpenJp2ImageWriter extends ImageWriter {
   }
 
   @Override
-  public IIOMetadata convertImageMetadata(IIOMetadata inData, ImageTypeSpecifier imageType, ImageWriteParam param) {
+  public IIOMetadata convertImageMetadata(
+      IIOMetadata inData, ImageTypeSpecifier imageType, ImageWriteParam param) {
     return null;
   }
 
   @Override
-  public void write(IIOMetadata streamMetadata, IIOImage image, ImageWriteParam param) throws IOException {
+  public void write(IIOMetadata streamMetadata, IIOImage image, ImageWriteParam param)
+      throws IOException {
     RenderedImage img = image.getRenderedImage();
     if (param == null) {
       param = getDefaultWriteParam();

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageWriterSpi.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageWriterSpi.java
@@ -1,5 +1,8 @@
 package de.digitalcollections.openjpeg.imageio;
 
+import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
+import static java.awt.image.BufferedImage.TYPE_BYTE_GRAY;
+
 import de.digitalcollections.openjpeg.OpenJpeg;
 import java.io.IOException;
 import java.util.Locale;
@@ -10,33 +13,46 @@ import javax.imageio.stream.ImageOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
-import static java.awt.image.BufferedImage.TYPE_BYTE_GRAY;
-
 @SuppressWarnings("checkstyle:constantname")
 public class OpenJp2ImageWriterSpi extends ImageWriterSpi {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenJp2ImageWriterSpi.class);
-  private static final String vendorName = "Münchener Digitalisierungszentrum/Digitale Bibliothek, Bayerische Staatsbibliothek";
+  private static final String vendorName =
+      "Münchener Digitalisierungszentrum/Digitale Bibliothek, Bayerische Staatsbibliothek";
   private static final String version = "0.2.6";
-  private static final String writerClassName = "de.digitalcollections.openjpeg.imageio.OpenJp2ImageWriter";
+  private static final String writerClassName =
+      "de.digitalcollections.openjpeg.imageio.OpenJp2ImageWriter";
   private static final String[] names = {"jpeg2000"};
   private static final String[] suffixes = {"jp2"};
   private static final String[] MIMETypes = {"image/jp2"};
-  private static final String[] readerSpiNames = {"de.digitalcollections.openjpeg.imageio.OpenJp2ImageWriterSpi"};
+  private static final String[] readerSpiNames = {
+    "de.digitalcollections.openjpeg.imageio.OpenJp2ImageWriterSpi"
+  };
   private static final Class[] outputTypes = {ImageOutputStream.class};
 
   private OpenJpeg lib;
 
-  /**
-   * Build the SPI, boilerplate.
-   */
+  /** Build the SPI, boilerplate. */
   public OpenJp2ImageWriterSpi() {
-    super(vendorName, version, names, suffixes, MIMETypes, writerClassName, outputTypes, readerSpiNames,
-            false, null, null,
-            null, null, false,
-            null, null, null,
-            null);
+    super(
+        vendorName,
+        version,
+        names,
+        suffixes,
+        MIMETypes,
+        writerClassName,
+        outputTypes,
+        readerSpiNames,
+        false,
+        null,
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        null);
   }
 
   private void loadLibrary() throws IOException {
@@ -54,7 +70,7 @@ public class OpenJp2ImageWriterSpi extends ImageWriterSpi {
   public boolean canEncodeImage(ImageTypeSpecifier type) {
     // TODO: Implement alpha support
     return ((type.getNumBands() == 3 && type.getBufferedImageType() == TYPE_3BYTE_BGR)
-            || (type.getNumBands() == 1 && type.getBufferedImageType() == TYPE_BYTE_GRAY));
+        || (type.getNumBands() == 1 && type.getBufferedImageType() == TYPE_BYTE_GRAY));
   }
 
   @Override

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/callbacks/opj_stream_read_fn.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/callbacks/opj_stream_read_fn.java
@@ -6,5 +6,6 @@ import jnr.ffi.types.size_t;
 
 public interface opj_stream_read_fn {
   @Delegate
-  @size_t long func(Pointer buffer, @size_t long numBytes, Pointer userData);
+  @size_t
+  long func(Pointer buffer, @size_t long numBytes, Pointer userData);
 }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/callbacks/opj_stream_skip_fn.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/callbacks/opj_stream_skip_fn.java
@@ -7,5 +7,6 @@ import jnr.ffi.types.size_t;
 
 public interface opj_stream_skip_fn {
   @Delegate
-  @int64_t long func(@size_t long numBytes, Pointer userData);
+  @int64_t
+  long func(@size_t long numBytes, Pointer userData);
 }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/callbacks/opj_stream_write_fn.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/callbacks/opj_stream_write_fn.java
@@ -6,5 +6,6 @@ import jnr.ffi.types.size_t;
 
 public interface opj_stream_write_fn {
   @Delegate
-  @size_t long func(Pointer buffer, @size_t long numBytes, Pointer userData);
+  @size_t
+  long func(Pointer buffer, @size_t long numBytes, Pointer userData);
 }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/enums/CODEC_FORMAT.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/enums/CODEC_FORMAT.java
@@ -11,9 +11,11 @@ public enum CODEC_FORMAT implements EnumMapper.IntegerEnum {
   OPJ_CODEC_JPX(4);
 
   private final int value;
-  CODEC_FORMAT(int value){
+
+  CODEC_FORMAT(int value) {
     this.value = value;
   }
+
   public int intValue() {
     return value;
   }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/libopenjp2.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/libopenjp2.java
@@ -25,49 +25,72 @@ public interface libopenjp2 {
   int STR_LEN = 4096;
   int JPWL_MAX_NO_TILESPECS = 16;
   int JPWL_MAX_NO_PACKSPECS = 16;
-  int OPJ_J2K_MAXRLVLS = 33 ;
-  int OPJ_J2K_MAXBANDS = (3*OPJ_J2K_MAXRLVLS-2);
+  int OPJ_J2K_MAXRLVLS = 33;
+  int OPJ_J2K_MAXBANDS = (3 * OPJ_J2K_MAXRLVLS - 2);
   long OPJ_J2K_STREAM_CHUNK_SIZE = 0x100000;
 
   String opj_version();
 
   /* Stream functions */
   Pointer opj_stream_create_default_file_stream(String filename, boolean isReadStream);
+
   Pointer opj_stream_create(@size_t long bufSize, boolean isInput);
+
   void opj_stream_set_read_function(Pointer stream, opj_stream_read_fn read_fn);
+
   void opj_stream_set_write_function(Pointer stream, opj_stream_write_fn write_fn);
+
   void opj_stream_set_skip_function(Pointer stream, opj_stream_skip_fn skip_fn);
+
   void opj_stream_set_seek_function(Pointer stream, opj_stream_seek_fn seek_fn);
+
   void opj_stream_set_user_data_length(Pointer stream, @u_int64_t long dataLength);
+
   void opj_stream_destroy(Pointer stream);
 
   /* Decoding functions */
   Pointer opj_create_decompress(CODEC_FORMAT fmt);
+
   void opj_destroy_codec(Pointer codec);
+
   boolean opj_read_header(Pointer stream, Pointer codec, @Out PointerByReference imgPtr);
+
   boolean opj_setup_decoder(Pointer codec, opj_dparameters params);
+
   void opj_set_default_decoder_parameters(opj_dparameters params);
-  boolean opj_set_decode_area(Pointer codec, Pointer image, int startX, int startY, int endX, int endY);
+
+  boolean opj_set_decode_area(
+      Pointer codec, Pointer image, int startX, int startY, int endX, int endY);
+
   boolean opj_decode(Pointer codec, Pointer stream, Pointer img);
 
   /* Encoding functions */
   Pointer opj_create_compress(CODEC_FORMAT fmt);
+
   void opj_set_default_encoder_parameters(@Direct opj_cparameters params);
+
   boolean opj_setup_encoder(Pointer codec, opj_cparameters params, opj_image img);
+
   boolean opj_start_compress(Pointer codec, opj_image img, Pointer stream);
+
   boolean opj_end_compress(Pointer codec, Pointer stream);
+
   boolean opj_encode(Pointer codec, Pointer stream);
 
   /* opj_image functions */
   Pointer opj_image_create(@u_int32_t int numcmpts, Pointer cmtparms, COLOR_SPACE clrspc);
+
   void opj_image_destroy(Pointer image);
 
   /* Info functions */
   opj_codestream_info_v2 opj_get_cstr_info(Pointer codec);
+
   void opj_destroy_cstr_info(AddressByReference infoPtr);
 
   /* Logging functions */
   boolean opj_set_info_handler(Pointer codec, opj_msg_callback msg_fn);
+
   boolean opj_set_warning_handler(Pointer codec, opj_msg_callback msg_fn);
+
   boolean opj_set_error_handler(Pointer codec, opj_msg_callback msg_fn);
 }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_codestream_info_v2.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_codestream_info_v2.java
@@ -19,7 +19,7 @@ public class opj_codestream_info_v2 extends Struct {
   /** number of tiles in Y */
   public Unsigned32 th;
 
-  /** number of components*/
+  /** number of components */
   public Unsigned32 nbcomps;
 
   /** Default information regarding tiles inside image */
@@ -29,7 +29,8 @@ public class opj_codestream_info_v2 extends Struct {
 
   public opj_codestream_info_v2(Runtime runtime) {
     super(runtime);
-    // NOTE: We run the initializers in the constructor, since we need an instantiated runtime for the
+    // NOTE: We run the initializers in the constructor, since we need an instantiated runtime for
+    // the
     //       inner struct
     tx0 = new Unsigned32();
     ty0 = new Unsigned32();
@@ -44,7 +45,8 @@ public class opj_codestream_info_v2 extends Struct {
 
   public void free(libopenjp2 lib) {
     if (this.tx0.getMemory().address() != 0) {
-      AddressByReference addr = new AddressByReference(jnr.ffi.Address.valueOf(this.tx0.getMemory().address()));
+      AddressByReference addr =
+          new AddressByReference(jnr.ffi.Address.valueOf(this.tx0.getMemory().address()));
       lib.opj_destroy_cstr_info(addr);
     }
   }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_cparameters.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_cparameters.java
@@ -36,12 +36,15 @@ public class opj_cparameters extends Struct {
   public Unsigned32 numpocs = new Unsigned32();
   /** number of layers */
   public Signed32 tcp_numlayers = new Signed32();
-  /** rates of layers - might be subsequently limited by the max_cs_size field.
-   * Should be decreasing. 1 can be
-   * used as last value to indicate the last layer is lossless. */
+  /**
+   * rates of layers - might be subsequently limited by the max_cs_size field. Should be decreasing.
+   * 1 can be used as last value to indicate the last layer is lossless.
+   */
   public Float[] tcp_rates = array(new Float[100]);
-  /** different psnr for successive layers. Should be increasing. 0 can be
-   * used as last value to indicate the last layer is lossless. */
+  /**
+   * different psnr for successive layers. Should be increasing. 0 can be used as last value to
+   * indicate the last layer is lossless.
+   */
   public Float[] tcp_distoratio = array(new Float[100]);
   /** number of resolutions */
   public Signed32 numresolution = new Signed32();
@@ -64,15 +67,21 @@ public class opj_cparameters extends Struct {
   /** initial precinct height */
   public Signed32[] prch_init = array(new Signed32[libopenjp2.OPJ_J2K_MAXRLVLS]);
 
-  /**@name command line encoder parameters (not used inside the library) */
-    /*@{*/
+  /** @name command line encoder parameters (not used inside the library) */
+  /*@{*/
   /** input file name */
   String infile = new AsciiString(libopenjp2.OPJ_PATH_LEN);
   /** output file name */
   String outfile = new AsciiString(libopenjp2.OPJ_PATH_LEN);
-  /** DEPRECATED. Index generation is now handeld with the opj_encode_with_info() function. Set to NULL */
+  /**
+   * DEPRECATED. Index generation is now handeld with the opj_encode_with_info() function. Set to
+   * NULL
+   */
   public Signed32 index_on = new Signed32();
-  /** DEPRECATED. Index generation is now handeld with the opj_encode_with_info() function. Set to NULL */
+  /**
+   * DEPRECATED. Index generation is now handeld with the opj_encode_with_info() function. Set to
+   * NULL
+   */
   String index = new AsciiString(libopenjp2.OPJ_PATH_LEN);
   /** subimage encoding: origin image offset in x direction */
   Signed32 image_offset_x0 = new Signed32();
@@ -82,15 +91,16 @@ public class opj_cparameters extends Struct {
   Signed32 subsampling_dx = new Signed32();
   /** subsampling value for dy */
   Signed32 subsampling_dy = new Signed32();
-  /** input file format 0: PGX, 1: PxM, 2: BMP 3:TIF*/
+  /** input file format 0: PGX, 1: PxM, 2: BMP 3:TIF */
   Signed32 decod_format = new Signed32();
   /** output file format 0: J2K, 1: JP2, 2: JPT */
   Signed32 cod_format = new Signed32();
-    /*@}*/
+  /*@}*/
 
-    /* UniPG>> */ /* NOT YET USED IN THE V2 VERSION OF OPENJPEG */
-  /**@name JPWL encoding parameters */
-    /*@{*/
+  /* UniPG>> */
+  /* NOT YET USED IN THE V2 VERSION OF OPENJPEG */
+  /** @name JPWL encoding parameters */
+  /*@{*/
   /** enables writing of EPC in MH, thus activating JPWL */
   public Boolean jpwl_epc_on = new Boolean();
   /** error protection method for MH (0,1,16,32,37-128) */
@@ -117,51 +127,48 @@ public class opj_cparameters extends Struct {
   Signed32[] jpwl_sens_TPH_tileno = array(new Signed32[libopenjp2.JPWL_MAX_NO_TILESPECS]);
   /** sensitivity methods for TPHs (-1=no,0-7) */
   Signed32[] jpwl_sens_TPH = array(new Signed32[libopenjp2.JPWL_MAX_NO_TILESPECS]);
-    /*@}*/
-    /* <<UniPG */
+  /*@}*/
+  /* <<UniPG */
 
   /**
-   * DEPRECATED: use RSIZ, OPJ_PROFILE_* and MAX_COMP_SIZE instead
-   * Digital Cinema compliance 0-not compliant, 1-compliant
-   * */
+   * DEPRECATED: use RSIZ, OPJ_PROFILE_* and MAX_COMP_SIZE instead Digital Cinema compliance 0-not
+   * compliant, 1-compliant
+   */
   Signed32 cp_cinema = new Signed32();
   /**
-   * Maximum size (in bytes) for each component.
-   * If == 0, component size limitation is not considered
-   * */
+   * Maximum size (in bytes) for each component. If == 0, component size limitation is not
+   * considered
+   */
   Signed32 max_comp_size = new Signed32();
-  /**
-   * DEPRECATED: use RSIZ, OPJ_PROFILE_* and OPJ_EXTENSION_* instead
-   * Profile name
-   * */
+  /** DEPRECATED: use RSIZ, OPJ_PROFILE_* and OPJ_EXTENSION_* instead Profile name */
   Signed32 cp_rsiz = new Signed32();
-  /** Tile part generation*/
+  /** Tile part generation */
   Unsigned8 tp_on = new Unsigned8();
-  /** Flag for Tile part generation*/
+  /** Flag for Tile part generation */
   Unsigned8 tp_flag = new Unsigned8();
   /** MCT (multiple component transform) */
   public Unsigned8 tcp_mct = new Unsigned8();
-  /** Enable JPIP indexing*/
+  /** Enable JPIP indexing */
   Boolean jpip_on = new Boolean();
-  /** Naive implementation of MCT restricted to a single reversible array based
-   encoding without offset concerning all the components. */
+  /**
+   * Naive implementation of MCT restricted to a single reversible array based encoding without
+   * offset concerning all the components.
+   */
   Pointer mct_data = new Pointer();
   /**
-   * Maximum size (in bytes) for the whole codestream.
-   * If == 0, codestream size limitation is not considered
-   * If it does not comply with tcp_rates, max_cs_size prevails
-   * and a warning is issued.
-   * */
+   * Maximum size (in bytes) for the whole codestream. If == 0, codestream size limitation is not
+   * considered If it does not comply with tcp_rates, max_cs_size prevails and a warning is issued.
+   */
   Signed32 max_cs_size = new Signed32();
-  /** RSIZ value
-   To be used to combine OPJ_PROFILE_*, OPJ_EXTENSION_* and (sub)levels values. */
+  /** RSIZ value To be used to combine OPJ_PROFILE_*, OPJ_EXTENSION_* and (sub)levels values. */
   Unsigned16 rsiz = new Unsigned16();
 
   public opj_cparameters(Runtime runtime) {
     super(runtime);
-    // FIXME: For some reason this is neccessary, even though the `array(...)` call does exactly this.
+    // FIXME: For some reason this is neccessary, even though the `array(...)` call does exactly
+    // this.
     // Removing it causes a double free crash
-    for (int i=0; i < this.POC.length; i++) {
+    for (int i = 0; i < this.POC.length; i++) {
       this.POC[i] = inner(new opj_poc(runtime));
     }
   }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_dparameters.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_dparameters.java
@@ -20,19 +20,20 @@ public class opj_dparameters extends Struct {
   public final Signed32 subsampling_dx = new Signed32();
   /** subsampling value for dy */
   public final Signed32 subsampling_dy = new Signed32();
-  /** input file format 0: PGX, 1: PxM, 2: BMP 3:TIF*/
+  /** input file format 0: PGX, 1: PxM, 2: BMP 3:TIF */
   public final Signed32 decod_format = new Signed32();
   /** output file format 0: J2K, 1: JP2, 2: JPT */
   public final Signed32 cod_format = new Signed32();
 
   /* NOT YET USED IN THE V2 VERSION OF OPENJPEG */
- /* JPWL encoding parameters */
+  /* JPWL encoding parameters */
   /** enables writing of EPC in MH, thus activating JPWL */
   public final Boolean jpwl_epc_on = new Boolean();
   /** error protection method for MH (0,1,16,32,37-128) */
   public final Signed32 jpwl_hprot_MH = new Signed32();
   /** tile number of header protection specification (&ge;0) */
-  public final Signed32[] jpwl_hprot_TPH_tileno = array(new Signed32[libopenjp2.JPWL_MAX_NO_TILESPECS]);
+  public final Signed32[] jpwl_hprot_TPH_tileno =
+      array(new Signed32[libopenjp2.JPWL_MAX_NO_TILESPECS]);
   /** error protection methods for TPHs (0,1,16,32,37-128) */
   public final Signed32[] jpwl_hprot_TPH = array(new Signed32[libopenjp2.JPWL_MAX_NO_TILESPECS]);
   /** tile number of packet protection specification (&ge;0) */
@@ -50,45 +51,42 @@ public class opj_dparameters extends Struct {
   /** sensitivity method for MH (-1=no,0-7) */
   public final Signed32 jpwl_sens_MH = new Signed32();
   /** tile number of sensitivity specification (&ge;0) */
-  public final Signed32[] jpwl_sens_TPH_tileno = array(new Signed32[libopenjp2.JPWL_MAX_NO_TILESPECS]);
+  public final Signed32[] jpwl_sens_TPH_tileno =
+      array(new Signed32[libopenjp2.JPWL_MAX_NO_TILESPECS]);
   /** sensitivity methods for TPHs (-1=no,0-7) */
   public final Signed32[] jpwl_sens_TPH = array(new Signed32[libopenjp2.JPWL_MAX_NO_TILESPECS]);
 
   /**
-   * DEPRECATED: use RSIZ, OPJ_PROFILE_* and MAX_COMP_SIZE instead
-   * Digital Cinema compliance 0-not compliant, 1-compliant
-   * */
+   * DEPRECATED: use RSIZ, OPJ_PROFILE_* and MAX_COMP_SIZE instead Digital Cinema compliance 0-not
+   * compliant, 1-compliant
+   */
   public final Signed32 cp_cinema = new Signed32();
   /**
-   * Maximum size (in bytes) for each component.
-   * If == 0, component size limitation is not considered
-   * */
+   * Maximum size (in bytes) for each component. If == 0, component size limitation is not
+   * considered
+   */
   public final Signed32 max_comp_size = new Signed32();
-  /**
-   * DEPRECATED: use RSIZ, OPJ_PROFILE_* and OPJ_EXTENSION_* instead
-   * Profile name
-   * */
+  /** DEPRECATED: use RSIZ, OPJ_PROFILE_* and OPJ_EXTENSION_* instead Profile name */
   public final Signed32 cp_rsiz = new Signed32();
-  /** Tile part generation*/
+  /** Tile part generation */
   public final Signed32 tp_on = new Signed32();
-  /** Flag for Tile part generation*/
+  /** Flag for Tile part generation */
   public final Signed32 tp_flag = new Signed32();
   /** MCT (multiple component transform) */
   public final Signed32 tcp_mct = new Signed32();
-  /** Enable JPIP indexing*/
+  /** Enable JPIP indexing */
   public final Boolean jpip_on = new Boolean();
-  /** Naive implementation of MCT restricted to a single reversible array based
-       encoding without offset concerning all the components. */
+  /**
+   * Naive implementation of MCT restricted to a single reversible array based encoding without
+   * offset concerning all the components.
+   */
   public final Pointer mct_data = new Pointer();
   /**
-   * Maximum size (in bytes) for the whole codestream.
-   * If == 0, codestream size limitation is not considered
-   * If it does not comply with tcp_rates, max_cs_size prevails
-   * and a warning is issued.
-   * */
+   * Maximum size (in bytes) for the whole codestream. If == 0, codestream size limitation is not
+   * considered If it does not comply with tcp_rates, max_cs_size prevails and a warning is issued.
+   */
   public final Signed32 max_cs_size = new Signed32();
-  /** RSIZ value
-      To be used to combine OPJ_PROFILE_*, OPJ_EXTENSION_* and (sub)levels values. */
+  /** RSIZ value To be used to combine OPJ_PROFILE_*, OPJ_EXTENSION_* and (sub)levels values. */
   public final Unsigned16 rsiz = new Unsigned16();
 
   public opj_dparameters(Runtime runtime) {

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image.java
@@ -6,9 +6,14 @@ import jnr.ffi.Runtime;
 import jnr.ffi.Struct;
 
 public class opj_image extends Struct {
-  /** XOsiz: horizontal offset from the origin of the reference grid to the left side of the image area */
+  /**
+   * XOsiz: horizontal offset from the origin of the reference grid to the left side of the image
+   * area
+   */
   public u_int32_t x0 = new u_int32_t();
-  /** YOsiz: vertical offset from the origin of the reference grid to the top side of the image area */
+  /**
+   * YOsiz: vertical offset from the origin of the reference grid to the top side of the image area
+   */
   public Unsigned32 y0 = new Unsigned32();
   /** Xsiz: width of the reference grid */
   public Unsigned32 x1 = new Unsigned32();

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image_comp.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image_comp.java
@@ -4,7 +4,9 @@ import jnr.ffi.Runtime;
 import jnr.ffi.Struct;
 
 public class opj_image_comp extends Struct {
-  /** XRsiz: horizontal separation of a sample of ith component with respect to the reference grid */
+  /**
+   * XRsiz: horizontal separation of a sample of ith component with respect to the reference grid
+   */
   Unsigned32 dx = new Unsigned32();
   /** YRsiz: vertical separation of a sample of ith component with respect to the reference grid */
   Unsigned32 dy = new Unsigned32();

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image_comptparm.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_image_comptparm.java
@@ -4,7 +4,9 @@ import jnr.ffi.Runtime;
 import jnr.ffi.Struct;
 
 public class opj_image_comptparm extends Struct {
-  /** XRsiz: horizontal separation of a sample of ith component with respect to the reference grid */
+  /**
+   * XRsiz: horizontal separation of a sample of ith component with respect to the reference grid
+   */
   public Unsigned32 dx = new Unsigned32();
   /** YRsiz: vertical separation of a sample of ith component with respect to the reference grid */
   public Unsigned32 dy = new Unsigned32();

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_poc.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_poc.java
@@ -7,39 +7,47 @@ import jnr.ffi.Struct;
 public class opj_poc extends Struct {
   /** Resolution num start, Component num start, given by POC */
   Unsigned32 resno0 = new Unsigned32();
+
   Unsigned32 compno0 = new Unsigned32();
   /** Layer num end,Resolution num end, Component num end, given by POC */
   Unsigned32 layno1 = new Unsigned32();
+
   Unsigned32 resno1 = new Unsigned32();
   Unsigned32 compno1 = new Unsigned32();
   /** Layer num start,Precinct num start, Precinct num end */
   Unsigned32 layno0 = new Unsigned32();
+
   Unsigned32 precno0 = new Unsigned32();
   Unsigned32 precno1 = new Unsigned32();
-  /** Progression order enum*/
+  /** Progression order enum */
   Enum<PROG_ORDER> prg1 = new Enum<>(PROG_ORDER.class);
+
   Enum<PROG_ORDER> prg = new Enum<>(PROG_ORDER.class);
-  /** Progression order string*/
+  /** Progression order string */
   String progorder = new AsciiString(5);
   /** Tile number */
   Unsigned32 tile = new Unsigned32();
-  /** Start and end values for Tile width and height*/
+  /** Start and end values for Tile width and height */
   Signed32 tx0 = new Signed32();
+
   Signed32 tx1 = new Signed32();
   Signed32 ty0 = new Signed32();
   Signed32 ty1 = new Signed32();
-  /** Start value, initialised in pi_initialise_encode*/
+  /** Start value, initialised in pi_initialise_encode */
   Unsigned32 layS = new Unsigned32();
+
   Unsigned32 resS = new Unsigned32();
   Unsigned32 compS = new Unsigned32();
   Unsigned32 prcS = new Unsigned32();
   /** End value, initialised in pi_initialise_encode */
   Unsigned32 layE = new Unsigned32();
+
   Unsigned32 resE = new Unsigned32();
   Unsigned32 compE = new Unsigned32();
   Unsigned32 prcE = new Unsigned32();
-  /** Start and end values of Tile width and height, initialised in pi_initialise_encode*/
+  /** Start and end values of Tile width and height, initialised in pi_initialise_encode */
   Unsigned32 txS = new Unsigned32();
+
   Unsigned32 txE = new Unsigned32();
   Unsigned32 tyS = new Unsigned32();
   Unsigned32 tyE = new Unsigned32();
@@ -47,6 +55,7 @@ public class opj_poc extends Struct {
   Unsigned32 dy = new Unsigned32();
   /** Temporary values for Tile parts, initialised in pi_create_encode */
   Unsigned32 lay_t = new Unsigned32();
+
   Unsigned32 res_t = new Unsigned32();
   Unsigned32 comp_t = new Unsigned32();
   Unsigned32 prc_t = new Unsigned32();

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_tccp_info.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_tccp_info.java
@@ -34,7 +34,6 @@ public class opj_tccp_info extends Struct {
   /** precinct height */
   public Unsigned32[] prch = new Unsigned32[libopenjp2.OPJ_J2K_MAXRLVLS];
 
-
   public opj_tccp_info(Runtime runtime) {
     super(runtime);
   }

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_tile_v2_info.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/structs/opj_tile_v2_info.java
@@ -15,7 +15,7 @@ public class opj_tile_v2_info extends Struct {
   /** multi-component transform identifier */
   public Unsigned32 mct = new Unsigned32();
 
-  /** information concerning tile component parameters*/
+  /** information concerning tile component parameters */
   public StructRef<opj_tccp_info> tccp_info = new StructRef<>(opj_tccp_info.class);
 
   public opj_tile_v2_info(Runtime runtime) {

--- a/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderTest.java
+++ b/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReaderTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.openjpeg.imageio;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.File;
@@ -9,8 +11,6 @@ import javax.imageio.ImageReadParam;
 import javax.imageio.ImageReader;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 class OpenJp2ImageReaderTest {
 
@@ -95,8 +95,9 @@ class OpenJp2ImageReaderTest {
     ImageReader reader = getReader("rgb.jp2");
     BufferedImage rgbImg = reader.read(0, null);
 
-    reader.setInput(ImageIO.createImageInputStream(
-        new File(ClassLoader.getSystemResource("hires.jp2").getFile())));
+    reader.setInput(
+        ImageIO.createImageInputStream(
+            new File(ClassLoader.getSystemResource("hires.jp2").getFile())));
     BufferedImage bwImg = reader.read(0, null);
 
     assertThat(rgbImg.getRGB(256, 256)).isNotEqualTo(bwImg.getRGB(256, 256));

--- a/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageWriterTest.java
+++ b/imageio-openjpeg/src/test/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageWriterTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.openjpeg.imageio;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import de.digitalcollections.openjpeg.OpenJpeg;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
@@ -16,9 +18,6 @@ import javax.imageio.stream.ImageOutputStream;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 
 class OpenJp2ImageWriterTest {
   private OpenJp2ImageWriter writer;
@@ -45,9 +44,10 @@ class OpenJp2ImageWriterTest {
     OpenJpeg lib = new OpenJpeg();
     // We need to pin the version so we can reliably compare checksums
     if (!lib.lib.opj_version().equals("2.3.0")) {
-      throw new RuntimeException(String.format(
-          "Writer tests must be run with version 2.3.0 of the shared library (installed version is %s)",
-          lib.lib.opj_version()));
+      throw new RuntimeException(
+          String.format(
+              "Writer tests must be run with version 2.3.0 of the shared library (installed version is %s)",
+              lib.lib.opj_version()));
     }
     writer = (OpenJp2ImageWriter) ImageIO.getImageWritersByFormatName("jpeg2000").next();
   }
@@ -61,14 +61,18 @@ class OpenJp2ImageWriterTest {
       writer.write(null, new IIOImage(in, null, null), param);
     }
     os.flush();
-    assertThat(sha1digest(new ByteArrayInputStream(os.toByteArray()))).isEqualTo(sha1digest(expected));
+    assertThat(sha1digest(new ByteArrayInputStream(os.toByteArray())))
+        .isEqualTo(sha1digest(expected));
   }
 
   @Test
   void writerIsDiscoverable() {
-    assertThat(Lists.newArrayList(ImageIO.getImageWritersByFormatName("jpeg2000"))).hasAtLeastOneElementOfType(OpenJp2ImageWriter.class);
-    assertThat(Lists.newArrayList(ImageIO.getImageWritersByMIMEType("image/jp2"))).hasAtLeastOneElementOfType(OpenJp2ImageWriter.class);
-    assertThat(Lists.newArrayList(ImageIO.getImageWritersBySuffix("jp2"))).hasAtLeastOneElementOfType(OpenJp2ImageWriter.class);
+    assertThat(Lists.newArrayList(ImageIO.getImageWritersByFormatName("jpeg2000")))
+        .hasAtLeastOneElementOfType(OpenJp2ImageWriter.class);
+    assertThat(Lists.newArrayList(ImageIO.getImageWritersByMIMEType("image/jp2")))
+        .hasAtLeastOneElementOfType(OpenJp2ImageWriter.class);
+    assertThat(Lists.newArrayList(ImageIO.getImageWritersBySuffix("jp2")))
+        .hasAtLeastOneElementOfType(OpenJp2ImageWriter.class);
   }
 
   @Test
@@ -89,7 +93,8 @@ class OpenJp2ImageWriterTest {
       writer.write(null, new IIOImage(in, null, null), param);
     }
     os.flush();
-    assertThat(sha1digest(new ByteArrayInputStream(os.toByteArray()))).isEqualTo(sha1digest(expected));
+    assertThat(sha1digest(new ByteArrayInputStream(os.toByteArray())))
+        .isEqualTo(sha1digest(expected));
   }
 
   @Test

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/Info.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/Info.java
@@ -40,33 +40,35 @@ public class Info {
     return (dim * num + denom - 1) / denom;
   }
 
-  /**
-   * Create a new instance with the information parsed from the JPEG image.
-   */
+  /** Create a new instance with the information parsed from the JPEG image. */
   public Info(int width, int height, int subsampling, int colorspace, tjscalingfactor[] factors) {
     this.width = width;
     this.height = height;
     this.subsampling = TJSAMP.fromInt(subsampling);
     this.colorspace = TJCS.fromInt(colorspace);
     // The available sizes are determined from the list of scaling factors.
-    this.availableSizes = Arrays.stream(factors)
-        .filter(f -> f.denom.get() > 0)
-        .sorted(Comparator.comparing(f -> -getScaled(width, f.num.get(), f.denom.get())))
-        .map(f -> new Dimension(getScaled(width, f.num.get(), f.denom.get()),
-                                getScaled(height, f.num.get(), f.denom.get())))
-        .filter(d -> d.width <= width && d.height <= height && d.width > 0 && d.height > 0)
-        .distinct()
-        .collect(Collectors.toList());
+    this.availableSizes =
+        Arrays.stream(factors)
+            .filter(f -> f.denom.get() > 0)
+            .sorted(Comparator.comparing(f -> -getScaled(width, f.num.get(), f.denom.get())))
+            .map(
+                f ->
+                    new Dimension(
+                        getScaled(width, f.num.get(), f.denom.get()),
+                        getScaled(height, f.num.get(), f.denom.get())))
+            .filter(d -> d.width <= width && d.height <= height && d.width > 0 && d.height > 0)
+            .distinct()
+            .collect(Collectors.toList());
   }
 
   /**
    * Get the size of the Minimum Coding Units.
    *
-   * Neccessary to calculate the right cropping alignments.
+   * <p>Neccessary to calculate the right cropping alignments.
    */
   public Dimension getMCUSize() {
     switch (subsampling) {
-      case TJSAMP_422:  // 4:2:2
+      case TJSAMP_422: // 4:2:2
         return new Dimension(16, 8);
       case TJSAMP_420:
         return new Dimension(16, 16);

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReadParam.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReadParam.java
@@ -6,7 +6,8 @@ import javax.imageio.plugins.jpeg.JPEGImageReadParam;
 /**
  * Parameters for reading JPEG images.
  *
- * Currently the only extra setting apart from the default ImageIO ones is setting the rotation degree.
+ * <p>Currently the only extra setting apart from the default ImageIO ones is setting the rotation
+ * degree.
  */
 public class TurboJpegImageReadParam extends JPEGImageReadParam {
 

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderSpi.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderSpi.java
@@ -20,27 +20,42 @@ import org.slf4j.LoggerFactory;
 public class TurboJpegImageReaderSpi extends ImageReaderSpi {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TurboJpegImageReaderSpi.class);
-  private static byte[] HEADER_MAGIC = new byte[]{(byte) 0xff, (byte) 0xd8};
-  private static final String vendorName = "Münchener Digitalisierungszentrum/Digitale Bibliothek, Bayerische Staatsbibliothek";
+  private static byte[] HEADER_MAGIC = new byte[] {(byte) 0xff, (byte) 0xd8};
+  private static final String vendorName =
+      "Münchener Digitalisierungszentrum/Digitale Bibliothek, Bayerische Staatsbibliothek";
   private static final String version = "0.2.6";
-  private static final String readerClassName = "de.digitalcollections.openjpeg.turbojpeg.TurboJpegImageReader";
+  private static final String readerClassName =
+      "de.digitalcollections.openjpeg.turbojpeg.TurboJpegImageReader";
   private static final String[] names = {"JPEG", "jpeg", "JPG", "jpg"};
   private static final String[] suffixes = {"jpg", "jpeg"};
   private static final String[] MIMETypes = {"image/jpeg"};
-  private static final String[] writerSpiNames = {"de.digitalcollections.turbojpeg.imageio.TurboJpegImageWriterSpi"};
+  private static final String[] writerSpiNames = {
+    "de.digitalcollections.turbojpeg.imageio.TurboJpegImageWriterSpi"
+  };
 
   private TurboJpeg lib;
 
-  /**
-   * Construct the SPI. Boilerplate.
-   */
+  /** Construct the SPI. Boilerplate. */
   public TurboJpegImageReaderSpi() {
-    super(vendorName, version, names, suffixes, MIMETypes, readerClassName,
-            new Class[]{ImageInputStream.class}, writerSpiNames,
-            false, null, null,
-            null, null, false,
-            null, null, null,
-            null);
+    super(
+        vendorName,
+        version,
+        names,
+        suffixes,
+        MIMETypes,
+        readerClassName,
+        new Class[] {ImageInputStream.class},
+        writerSpiNames,
+        false,
+        null,
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        null);
   }
 
   private void loadLibrary() throws IOException {
@@ -54,15 +69,18 @@ public class TurboJpegImageReaderSpi extends ImageReaderSpi {
     }
   }
 
-  /** Instruct registry to prioritize this ReaderSpi over other JPEG readers. **/
+  /** Instruct registry to prioritize this ReaderSpi over other JPEG readers. * */
   @SuppressWarnings("unchecked")
   @Override
   public void onRegistration(final ServiceRegistry registry, final Class<?> category) {
     Stream.of(
             "com.twelvemonkeys.imageio.plugins.jpeg.JPEGImageReaderSpi",
-            "com.sun.imageio.plugins.jpeg.JPEGImageReaderSpi").forEach((clsName) -> {
+            "com.sun.imageio.plugins.jpeg.JPEGImageReaderSpi")
+        .forEach(
+            (clsName) -> {
               try {
-                ImageReaderSpi defaultProvider = (ImageReaderSpi) registry.getServiceProviderByClass(Class.forName(clsName));
+                ImageReaderSpi defaultProvider =
+                    (ImageReaderSpi) registry.getServiceProviderByClass(Class.forName(clsName));
                 registry.setOrdering((Class<ImageReaderSpi>) category, this, defaultProvider);
               } catch (ClassNotFoundException e) {
                 // NOP

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageWriter.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageWriter.java
@@ -58,12 +58,14 @@ public class TurboJpegImageWriter extends ImageWriter {
   }
 
   @Override
-  public IIOMetadata convertImageMetadata(IIOMetadata inData, ImageTypeSpecifier imageType, ImageWriteParam param) {
+  public IIOMetadata convertImageMetadata(
+      IIOMetadata inData, ImageTypeSpecifier imageType, ImageWriteParam param) {
     return null;
   }
 
   @Override
-  public void write(IIOMetadata streamMetadata, IIOImage image, ImageWriteParam param) throws IOException {
+  public void write(IIOMetadata streamMetadata, IIOImage image, ImageWriteParam param)
+      throws IOException {
     RenderedImage img = image.getRenderedImage();
     if (stream == null) {
       throw new IOException("Set an output first!");

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageWriterSpi.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageWriterSpi.java
@@ -1,5 +1,9 @@
 package de.digitalcollections.turbojpeg.imageio;
 
+import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
+import static java.awt.image.BufferedImage.TYPE_4BYTE_ABGR;
+import static java.awt.image.BufferedImage.TYPE_BYTE_GRAY;
+
 import com.google.common.collect.ImmutableSet;
 import de.digitalcollections.turbojpeg.TurboJpeg;
 import java.io.IOException;
@@ -13,33 +17,46 @@ import javax.imageio.stream.ImageOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
-import static java.awt.image.BufferedImage.TYPE_4BYTE_ABGR;
-import static java.awt.image.BufferedImage.TYPE_BYTE_GRAY;
-
 @SuppressWarnings("checkstyle:constantname")
 public class TurboJpegImageWriterSpi extends ImageWriterSpi {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TurboJpegImageWriterSpi.class);
-  private static final String vendorName = "Münchener Digitalisierungszentrum/Digitale Bibliothek, Bayerische Staatsbibliothek";
+  private static final String vendorName =
+      "Münchener Digitalisierungszentrum/Digitale Bibliothek, Bayerische Staatsbibliothek";
   private static final String version = "0.2.6";
-  private static final String writerClassName = "de.digitalcollections.openjpeg.turbojpeg.TurboJpegImageWriter";
+  private static final String writerClassName =
+      "de.digitalcollections.openjpeg.turbojpeg.TurboJpegImageWriter";
   private static final String[] names = {"JPEG", "jpeg", "JPG", "jpg"};
   private static final String[] suffixes = {"jpg", "jpeg"};
   private static final String[] MIMETypes = {"image/jpeg"};
-  private static final String[] readerSpiNames = {"de.digitalcollections.turbojpeg.imageio.TurboJpegImageReaderSpi"};
+  private static final String[] readerSpiNames = {
+    "de.digitalcollections.turbojpeg.imageio.TurboJpegImageReaderSpi"
+  };
   private static final Class[] outputTypes = {ImageOutputStream.class};
 
   private TurboJpeg lib;
 
-  /**
-   * Construct the SPI. Boilerplate.
-   */
+  /** Construct the SPI. Boilerplate. */
   public TurboJpegImageWriterSpi() {
-    super(vendorName, version, names, suffixes, MIMETypes, writerClassName, outputTypes, readerSpiNames,
-            false, null, null,
-            null, null, false,
-            null, null, null, null);
+    super(
+        vendorName,
+        version,
+        names,
+        suffixes,
+        MIMETypes,
+        writerClassName,
+        outputTypes,
+        readerSpiNames,
+        false,
+        null,
+        null,
+        null,
+        null,
+        false,
+        null,
+        null,
+        null,
+        null);
   }
 
   private void loadLibrary() throws IOException {
@@ -53,15 +70,18 @@ public class TurboJpegImageWriterSpi extends ImageWriterSpi {
     }
   }
 
-  /** Instruct registry to prioritize this WriterSpi over other JPEG writers. **/
+  /** Instruct registry to prioritize this WriterSpi over other JPEG writers. * */
   @SuppressWarnings("unchecked")
   @Override
   public void onRegistration(final ServiceRegistry registry, final Class<?> category) {
     Stream.of(
             "com.twelvemonkeys.imageio.plugins.jpeg.JPEGImageWriterSpi",
-            "com.sun.imageio.plugins.jpeg.JPEGImageWriterSpi").forEach((clsName) -> {
+            "com.sun.imageio.plugins.jpeg.JPEGImageWriterSpi")
+        .forEach(
+            (clsName) -> {
               try {
-                ImageWriterSpi defaultProvider = (ImageWriterSpi) registry.getServiceProviderByClass(Class.forName(clsName));
+                ImageWriterSpi defaultProvider =
+                    (ImageWriterSpi) registry.getServiceProviderByClass(Class.forName(clsName));
                 registry.setOrdering((Class<ImageWriterSpi>) category, this, defaultProvider);
               } catch (ClassNotFoundException e) {
                 // NOP
@@ -73,7 +93,8 @@ public class TurboJpegImageWriterSpi extends ImageWriterSpi {
   public boolean canEncodeImage(ImageTypeSpecifier type) {
     // TODO: Support all image types, if neccessary convert before encoding
     return ((type.getNumBands() == 3 || type.getNumBands() == 1)
-            && ImmutableSet.of(TYPE_3BYTE_BGR, TYPE_4BYTE_ABGR, TYPE_BYTE_GRAY).contains(type.getBufferedImageType()));
+        && ImmutableSet.of(TYPE_3BYTE_BGR, TYPE_4BYTE_ABGR, TYPE_BYTE_GRAY)
+            .contains(type.getBufferedImageType()));
   }
 
   @Override

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/lib/enums/TJPF.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/lib/enums/TJPF.java
@@ -1,12 +1,12 @@
 package de.digitalcollections.turbojpeg.lib.enums;
 
-import java.util.Arrays;
-import jnr.ffi.util.EnumMapper.IntegerEnum;
-
 import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
 import static java.awt.image.BufferedImage.TYPE_4BYTE_ABGR;
 import static java.awt.image.BufferedImage.TYPE_4BYTE_ABGR_PRE;
 import static java.awt.image.BufferedImage.TYPE_BYTE_GRAY;
+
+import java.util.Arrays;
+import jnr.ffi.util.EnumMapper.IntegerEnum;
 
 public enum TJPF implements IntegerEnum {
   TJPF_RGB(0),

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/lib/enums/TJXOPT.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/lib/enums/TJXOPT.java
@@ -1,9 +1,9 @@
 package de.digitalcollections.turbojpeg.lib.enums;
 
 public class TJXOPT {
-  public static int TJXOPT_PERFECT   = 1;
-  public static int TJXOPT_TRIM      = 2;
-  public static int TJXOPT_CROP      = 4;
-  public static int TJXOPT_GRAY      = 8;
+  public static int TJXOPT_PERFECT = 1;
+  public static int TJXOPT_TRIM = 2;
+  public static int TJXOPT_CROP = 4;
+  public static int TJXOPT_GRAY = 8;
   public static int TJX_OPT_NOOUTPUT = 16;
 }

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/lib/libturbojpeg.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/lib/libturbojpeg.java
@@ -14,24 +14,64 @@ import jnr.ffi.byref.PointerByReference;
 import jnr.ffi.types.u_int32_t;
 
 public interface libturbojpeg {
-  int tjCompress2(Pointer handle, Buffer srcBuf, int width, int pitch, int height, TJPF pixelFormat,
-                  @In PointerByReference jpegBuf, NativeLongByReference jpegSize,
-                  TJSAMP jpegSubsamp, int jpegQual, int flags);
-  int tjDecompress2(Pointer handle, @In Buffer jpegBuf, @u_int32_t long jpegSize, @Out Buffer dstBuf,
-                    int width, int pitch, int height, TJPF pixelFormat, int flags);
-  int tjDecompressHeader3(Pointer handle, Buffer jpegBuf, @u_int32_t long jpegSize,
-                          @Out IntByReference width, @Out IntByReference  height, @Out IntByReference jpegSubsamp,
-                          @Out IntByReference jpegColorspace);
-  int tjTransform(Pointer handle, Buffer jpegBuf, @u_int32_t long jpegSize, int n, PointerByReference outBuf,
-                  NativeLongByReference dstSizes, @Direct tjtransform transform, int flags);
-  int tjDestroy(Pointer handle);
-  void tjFree(Pointer bufPtr);
-  String tjGetErrorStr();
-  Pointer tjGetScalingFactors(@Out IntByReference numscalingfactors);
-  Pointer tjInitCompress();
-  Pointer tjInitDecompress();
-  Pointer tjInitTransform();
-  Pointer tjAlloc(int bytes);
-  long tjBufSize(int width, int height, TJSAMP subsamp);
+  int tjCompress2(
+      Pointer handle,
+      Buffer srcBuf,
+      int width,
+      int pitch,
+      int height,
+      TJPF pixelFormat,
+      @In PointerByReference jpegBuf,
+      NativeLongByReference jpegSize,
+      TJSAMP jpegSubsamp,
+      int jpegQual,
+      int flags);
 
+  int tjDecompress2(
+      Pointer handle,
+      @In Buffer jpegBuf,
+      @u_int32_t long jpegSize,
+      @Out Buffer dstBuf,
+      int width,
+      int pitch,
+      int height,
+      TJPF pixelFormat,
+      int flags);
+
+  int tjDecompressHeader3(
+      Pointer handle,
+      Buffer jpegBuf,
+      @u_int32_t long jpegSize,
+      @Out IntByReference width,
+      @Out IntByReference height,
+      @Out IntByReference jpegSubsamp,
+      @Out IntByReference jpegColorspace);
+
+  int tjTransform(
+      Pointer handle,
+      Buffer jpegBuf,
+      @u_int32_t long jpegSize,
+      int n,
+      PointerByReference outBuf,
+      NativeLongByReference dstSizes,
+      @Direct tjtransform transform,
+      int flags);
+
+  int tjDestroy(Pointer handle);
+
+  void tjFree(Pointer bufPtr);
+
+  String tjGetErrorStr();
+
+  Pointer tjGetScalingFactors(@Out IntByReference numscalingfactors);
+
+  Pointer tjInitCompress();
+
+  Pointer tjInitDecompress();
+
+  Pointer tjInitTransform();
+
+  Pointer tjAlloc(int bytes);
+
+  long tjBufSize(int width, int height, TJSAMP subsamp);
 }

--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/BufferedImageAssert.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/BufferedImageAssert.java
@@ -1,11 +1,10 @@
 package de.digitalcollections.turbojpeg.imageio;
 
-import org.assertj.core.api.AbstractAssert;
-
-import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import javax.imageio.ImageIO;
+import org.assertj.core.api.AbstractAssert;
 
 class BufferedImageAssert extends AbstractAssert<BufferedImageAssert, BufferedImage> {
   public BufferedImageAssert(BufferedImage actual) {
@@ -31,8 +30,8 @@ class BufferedImageAssert extends AbstractAssert<BufferedImageAssert, BufferedIm
     isNotNull();
     int w = actual.getWidth();
     int h = actual.getHeight();
-    for (int x=0; x < w; x++) {
-      for (int y=0; y < h; y++) {
+    for (int x = 0; x < w; x++) {
+      for (int y = 0; y < h; y++) {
         if (actual.getRGB(x, y) == rgbColor) {
           String debugFilename = null;
           failWithMessage(
@@ -47,8 +46,9 @@ class BufferedImageAssert extends AbstractAssert<BufferedImageAssert, BufferedIm
   public BufferedImageAssert hasDimensions(int width, int height) {
     isNotNull();
     if (actual.getWidth() != width || actual.getHeight() != height) {
-      failWithMessage("Expected image to be of size %dx%d, but is %dx%d.%s",
-                      width, height, actual.getWidth(), actual.getHeight(), writeDebugImage());
+      failWithMessage(
+          "Expected image to be of size %dx%d, but is %dx%d.%s",
+          width, height, actual.getWidth(), actual.getHeight(), writeDebugImage());
     }
     return this;
   }

--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/CustomAssertions.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/CustomAssertions.java
@@ -1,8 +1,7 @@
 package de.digitalcollections.turbojpeg.imageio;
 
-import org.assertj.core.api.Assertions;
-
 import java.awt.image.BufferedImage;
+import org.assertj.core.api.Assertions;
 
 class CustomAssertions extends Assertions {
   public static BufferedImageAssert assertThat(BufferedImage actual) {

--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TiffJpegImageReaderTest.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TiffJpegImageReaderTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.turbojpeg.imageio;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.twelvemonkeys.imageio.plugins.tiff.TIFFImageReader;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
@@ -13,8 +15,6 @@ import javax.imageio.ImageReader;
 import javax.imageio.stream.ImageInputStream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TiffJpegImageReaderTest {
   ImageReader getReader(Class<? extends ImageReader> clz) throws IOException {
@@ -31,12 +31,12 @@ public class TiffJpegImageReaderTest {
 
   private static Stream<Class<? extends ImageReader>> tiffReaders() {
     try {
-      Class<? extends ImageReader> sunReader = (Class<? extends ImageReader>) TiffJpegImageReaderTest.class
-          .getClassLoader()
-          .loadClass("com.sun.imageio.plugins.tiff.TIFFImageReader");
-      return Stream.of(
-          TIFFImageReader.class,
-          sunReader);
+      Class<? extends ImageReader> sunReader =
+          (Class<? extends ImageReader>)
+              TiffJpegImageReaderTest.class
+                  .getClassLoader()
+                  .loadClass("com.sun.imageio.plugins.tiff.TIFFImageReader");
+      return Stream.of(TIFFImageReader.class, sunReader);
     } catch (ClassNotFoundException e) {
       return Stream.of(TIFFImageReader.class);
     }

--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.turbojpeg.imageio;
 
+import static de.digitalcollections.turbojpeg.imageio.CustomAssertions.assertThat;
+
 import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
@@ -14,13 +16,12 @@ import javax.imageio.stream.ImageInputStream;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
 
-import static de.digitalcollections.turbojpeg.imageio.CustomAssertions.assertThat;
-
 class TurboJpegImageReaderTest {
 
   @Test
   public void testReaderIsRegistered() {
-    Supplier<List<ImageReader>> getReaderIter = () -> Lists.newArrayList(ImageIO.getImageReadersBySuffix("jpg"));
+    Supplier<List<ImageReader>> getReaderIter =
+        () -> Lists.newArrayList(ImageIO.getImageReadersBySuffix("jpg"));
     assertThat(getReaderIter.get()).isNotEmpty();
     assertThat(getReaderIter.get()).hasAtLeastOneElementOfType(TurboJpegImageReader.class);
     getReaderIter = () -> Lists.newArrayList(ImageIO.getImageReadersByMIMEType("image/jpeg"));
@@ -59,9 +60,7 @@ class TurboJpegImageReaderTest {
     ImageReadParam param = reader.getDefaultReadParam();
     param.setSourceRegion(new Rectangle(32, 32, 96, 96));
     BufferedImage img = reader.read(0, param);
-    assertThat(img)
-        .hasDimensions(96, 96)
-        .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(96, 96).hasNoPixelsOfColor(-1 /* white */);
   }
 
   @Test
@@ -70,9 +69,7 @@ class TurboJpegImageReaderTest {
     ImageReadParam param = reader.getDefaultReadParam();
     param.setSourceRegion(new Rectangle(116, 148, 204, 172));
     BufferedImage img = reader.read(0, param);
-    assertThat(img)
-        .hasDimensions(204, 172)
-        .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(204, 172).hasNoPixelsOfColor(-1 /* white */);
   }
 
   @Test
@@ -81,9 +78,7 @@ class TurboJpegImageReaderTest {
     ImageReadParam param = reader.getDefaultReadParam();
     param.setSourceRegion(new Rectangle(87, 111, 152, 129));
     BufferedImage img = reader.read(2, param);
-    assertThat(img)
-        .hasDimensions(152, 129)
-        .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(152, 129).hasNoPixelsOfColor(-1 /* white */);
   }
 
   @Test
@@ -93,19 +88,13 @@ class TurboJpegImageReaderTest {
     param.setSourceRegion(new Rectangle(16, 16, 339, 319));
     param.setRotationDegree(90);
     BufferedImage img = reader.read(0, param);
-    assertThat(img)
-        .hasDimensions(319, 339)
-        .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(319, 339).hasNoPixelsOfColor(-1 /* white */);
     param.setRotationDegree(180);
     img = reader.read(0, param);
-    assertThat(img)
-        .hasDimensions(339, 319)
-        .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(339, 319).hasNoPixelsOfColor(-1 /* white */);
     param.setRotationDegree(270);
     img = reader.read(0, param);
-    assertThat(img)
-        .hasDimensions(319, 339)
-        .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(319, 339).hasNoPixelsOfColor(-1 /* white */);
   }
 
   @Test
@@ -117,7 +106,8 @@ class TurboJpegImageReaderTest {
     img = img.getSubimage(192, 116, 172, 204);
 
     // Need to copy the image so we can check the image data
-    BufferedImage copy = new BufferedImage(img.getWidth(), img.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
+    BufferedImage copy =
+        new BufferedImage(img.getWidth(), img.getHeight(), BufferedImage.TYPE_3BYTE_BGR);
     Graphics g = copy.createGraphics();
     g.drawImage(img, 0, 0, null);
     assertThat(img).hasNoPixelsOfColor(-1);
@@ -130,19 +120,13 @@ class TurboJpegImageReaderTest {
     param.setSourceRegion(new Rectangle(116, 148, 204, 172));
     param.setRotationDegree(90);
     BufferedImage img = reader.read(0, param);
-    assertThat(img)
-        .hasDimensions(172, 204)
-        .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(172, 204).hasNoPixelsOfColor(-1 /* white */);
     param.setRotationDegree(180);
     img = reader.read(0, param);
-    assertThat(img)
-            .hasDimensions(204, 172)
-            .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(204, 172).hasNoPixelsOfColor(-1 /* white */);
     param.setRotationDegree(270);
     img = reader.read(0, param);
-    assertThat(img)
-            .hasDimensions(172, 204)
-            .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(172, 204).hasNoPixelsOfColor(-1 /* white */);
   }
 
   @Test
@@ -152,19 +136,13 @@ class TurboJpegImageReaderTest {
     param.setSourceRegion(new Rectangle(0, 0, 384, 368));
     param.setRotationDegree(90);
     BufferedImage img = reader.read(1, param);
-    assertThat(img)
-        .hasDimensions(368, 384)
-        .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(368, 384).hasNoPixelsOfColor(-1 /* white */);
     param.setRotationDegree(180);
     img = reader.read(1, param);
-    assertThat(img)
-            .hasDimensions(384, 368)
-            .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(384, 368).hasNoPixelsOfColor(-1 /* white */);
     param.setRotationDegree(270);
     img = reader.read(1, param);
-    assertThat(img)
-            .hasDimensions(368, 384)
-            .hasNoPixelsOfColor(-1 /* white */);
+    assertThat(img).hasDimensions(368, 384).hasNoPixelsOfColor(-1 /* white */);
   }
 
   @Test
@@ -172,8 +150,9 @@ class TurboJpegImageReaderTest {
     ImageReader reader = getReader("rgb.jpg");
     BufferedImage rgbImg = reader.read(1, null);
 
-    reader.setInput(ImageIO.createImageInputStream(
-        new File(ClassLoader.getSystemResource("crop_unaligned.jpg").getFile())));
+    reader.setInput(
+        ImageIO.createImageInputStream(
+            new File(ClassLoader.getSystemResource("crop_unaligned.jpg").getFile())));
     BufferedImage bwImg = reader.read(1, null);
 
     assertThat(rgbImg.getRGB(256, 256)).isNotEqualTo(bwImg.getRGB(256, 256));
@@ -221,8 +200,7 @@ class TurboJpegImageReaderTest {
     TurboJpegImageReadParam param = (TurboJpegImageReadParam) reader.getDefaultReadParam();
     param.setSourceRegion(new Rectangle(131, 57, 239, 397));
     BufferedImage img = reader.read(0, param);
-    assertThat(img).hasDimensions(239, 397)
-            .hasNoPixelsOfColor(-1);
+    assertThat(img).hasDimensions(239, 397).hasNoPixelsOfColor(-1);
   }
 
   @Test

--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageWriterTest.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageWriterTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.turbojpeg.imageio;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import java.awt.image.BufferedImage;
@@ -13,11 +15,11 @@ import javax.imageio.ImageWriter;
 import javax.imageio.stream.ImageOutputStream;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-/** NOTE: These tests can only be superficial, since TurboJPEG is merely a wrapping API for a number
- *  of different JPEG implementations and versions, which is why we cannot make bit-accurate assertions on the
- *  generated data. */
+/**
+ * NOTE: These tests can only be superficial, since TurboJPEG is merely a wrapping API for a number
+ * of different JPEG implementations and versions, which is why we cannot make bit-accurate
+ * assertions on the generated data.
+ */
 class TurboJpegImageWriterTest {
   @Test
   void writerIsDiscoverable() {
@@ -29,9 +31,11 @@ class TurboJpegImageWriterTest {
 
   @Test
   public void testEncode() throws IOException {
-    ImageWriter writer = Streams.stream(ImageIO.getImageWritersByFormatName("jpeg"))
-        .filter(TurboJpegImageWriter.class::isInstance)
-        .findFirst().get();
+    ImageWriter writer =
+        Streams.stream(ImageIO.getImageWritersByFormatName("jpeg"))
+            .filter(TurboJpegImageWriter.class::isInstance)
+            .findFirst()
+            .get();
     ImageWriteParam param = writer.getDefaultWriteParam();
     param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
     param.setCompressionQuality(0.85f);
@@ -47,9 +51,11 @@ class TurboJpegImageWriterTest {
 
   @Test
   public void testEncodeBinary() throws Exception {
-    ImageWriter writer = Streams.stream(ImageIO.getImageWritersByFormatName("jpeg"))
-        .filter(TurboJpegImageWriter.class::isInstance)
-        .findFirst().get();
+    ImageWriter writer =
+        Streams.stream(ImageIO.getImageWritersByFormatName("jpeg"))
+            .filter(TurboJpegImageWriter.class::isInstance)
+            .findFirst()
+            .get();
     ImageWriteParam param = writer.getDefaultWriteParam();
     param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
     param.setCompressionQuality(0.85f);
@@ -72,9 +78,11 @@ class TurboJpegImageWriterTest {
 
   @Test
   public void testCanReuseWriter() throws IOException {
-    ImageWriter writer = Streams.stream(ImageIO.getImageWritersByFormatName("jpeg"))
-        .filter(TurboJpegImageWriter.class::isInstance)
-        .findFirst().get();
+    ImageWriter writer =
+        Streams.stream(ImageIO.getImageWritersByFormatName("jpeg"))
+            .filter(TurboJpegImageWriter.class::isInstance)
+            .findFirst()
+            .get();
 
     BufferedImage in = ImageIO.read(ClassLoader.getSystemResource("rgb.jpg"));
     ByteArrayOutputStream rgb = new ByteArrayOutputStream();

--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,8 @@
 
     <!-- plugins -->
     <version.jacoco-maven-plugin>0.8.5</version.jacoco-maven-plugin>
-    <version.maven-checkstyle-plugin>3.1.0</version.maven-checkstyle-plugin>
     <version.maven-compiler-plugin>3.8.1</version.maven-compiler-plugin>
+    <version.maven-fmt-plugin>2.9</version.maven-fmt-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-javadoc-plugin>3.1.1</version.maven-javadoc-plugin>
     <version.maven-source-plugin>3.2.1</version.maven-source-plugin>
@@ -125,25 +125,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${version.maven-checkstyle-plugin}</version>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>${version.maven-fmt-plugin}</version>
         <executions>
           <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <configuration>
-              <configLocation>https://raw.githubusercontent.com/dbmdz/development/master/code-quality/checkstyle.xml</configLocation>
-              <encoding>UTF-8</encoding>
-              <consoleOutput>true</consoleOutput>
-              <failsOnError>true</failsOnError>
-              <excludes>
-                **/lib/**/*
-              </excludes>
-              <linkXRef>false</linkXRef>
-            </configuration>
             <goals>
-              <goal>check</goal>
+              <goal>format</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
This MR replaces checkstyle with a maven-plugin that automatically reformats the code to conform with the Google Java Style Guide during the format execution goal, which is executed during the standard clean install and clean test targets.