### PR TITLE
Demote guava to test dependency

### DIFF
--- a/imageio-turbojpeg/pom.xml
+++ b/imageio-turbojpeg/pom.xml
@@ -31,6 +31,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${version.guava}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <!-- For testing compatibility with JPEG in TIF -->

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReadParam.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReadParam.java
@@ -19,6 +19,7 @@ public class TurboJpegImageReadParam extends JPEGImageReadParam {
   public void setRotationDegree(int rotationDegree) {
     if (rotationDegree == 90 || rotationDegree == 180 || rotationDegree == 270) {
       this.rotationDegree = rotationDegree;
+      return;
     }
     throw new IllegalArgumentException("Illegal rotation, must be 90, 180 or 270");
   }

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReadParam.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReadParam.java
@@ -1,6 +1,5 @@
 package de.digitalcollections.turbojpeg.imageio;
 
-import com.google.common.collect.ImmutableSet;
 import javax.imageio.plugins.jpeg.JPEGImageReadParam;
 
 /**
@@ -18,9 +17,9 @@ public class TurboJpegImageReadParam extends JPEGImageReadParam {
   }
 
   public void setRotationDegree(int rotationDegree) {
-    if (!ImmutableSet.of(90, 180, 270).contains(rotationDegree)) {
-      throw new IllegalArgumentException("Illegal rotation, must be 90, 180 or 270");
+    if (rotationDegree == 90 || rotationDegree == 180 || rotationDegree == 270) {
+      this.rotationDegree = rotationDegree;
     }
-    this.rotationDegree = rotationDegree;
+    throw new IllegalArgumentException("Illegal rotation, must be 90, 180 or 270");
   }
 }

--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageWriterSpi.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageWriterSpi.java
@@ -4,7 +4,6 @@ import static java.awt.image.BufferedImage.TYPE_3BYTE_BGR;
 import static java.awt.image.BufferedImage.TYPE_4BYTE_ABGR;
 import static java.awt.image.BufferedImage.TYPE_BYTE_GRAY;
 
-import com.google.common.collect.ImmutableSet;
 import de.digitalcollections.turbojpeg.TurboJpeg;
 import java.io.IOException;
 import java.util.Locale;
@@ -91,10 +90,10 @@ public class TurboJpegImageWriterSpi extends ImageWriterSpi {
 
   @Override
   public boolean canEncodeImage(ImageTypeSpecifier type) {
-    // TODO: Support all image types, if neccessary convert before encoding
-    return ((type.getNumBands() == 3 || type.getNumBands() == 1)
-        && ImmutableSet.of(TYPE_3BYTE_BGR, TYPE_4BYTE_ABGR, TYPE_BYTE_GRAY)
-            .contains(type.getBufferedImageType()));
+    // TODO: Support all image types, if necessary convert before encoding
+    int bufferedImageType = type.getBufferedImageType();
+    return (type.getNumBands() == 3 || type.getNumBands() == 1)
+        && (bufferedImageType == TYPE_3BYTE_BGR || bufferedImageType == TYPE_4BYTE_ABGR || bufferedImageType == TYPE_BYTE_GRAY);
   }
 
   @Override


### PR DESCRIPTION
Guava is a big dependency that is not really needed outside of unit tests. This PR removes Guava as a dependency to use this library and restricts the scope for Guava to `test`.