### PR TITLE
Fix logging output (w×x instead of w×h)

### DIFF
--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReader.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReader.java
@@ -274,7 +274,7 @@ public class TurboJpegImageReader extends ImageReader {
                 region.x,
                 region.y,
                 getWidth(imageIndex),
-                getWidth(imageIndex)));
+                getHeight(imageIndex)));
       }
       if (region != null || rotation != 0) {
         data = lib.transform(data.array(), info, region, rotation);


### PR DESCRIPTION
Logging output in `TurboJpegImageReader` uses width twice, should use width and height.