### PR TITLE
Fix jpeg cropping edge case

### DIFF
--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/TurboJpeg.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/TurboJpeg.java
@@ -272,7 +272,8 @@ public class TurboJpeg {
             || ((region.y + region.height) != height && region.height % mcuSize.height != 0)) {
           throw new IllegalArgumentException(
               String.format(
-                  "Invalid cropping region, width must be divisible by %d, height by %d",
+                  "Invalid cropping region %d×%d, width must be divisible by %d, height by %d",
+                  region.width, region.height,
                   mcuSize.width, mcuSize.height));
         }
         width = region.width;

--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
@@ -2,6 +2,7 @@ package de.digitalcollections.turbojpeg.imageio;
 
 import static de.digitalcollections.turbojpeg.imageio.CustomAssertions.assertThat;
 
+import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
@@ -248,5 +249,22 @@ class TurboJpegImageReaderTest {
     BufferedImage img = reader.read(3, param);
     assertThat(img.getWidth()).isEqualTo(365);
     assertThat(img.getHeight()).isEqualTo(10);
+  }
+
+  @Test
+  void testAdjustMCURegion() throws IOException {
+    TurboJpegImageReader reader = new TurboJpegImageReader(null, null);
+
+    Dimension mcuSize = new Dimension(16, 16);
+    Rectangle region = new Rectangle(1185, 327, 309, 36);
+    int rotation = 0;
+    Dimension imageSize = new Dimension(1500, 2260);
+
+    Rectangle actual = reader.adjustRegion(mcuSize, region, rotation, imageSize);
+    Rectangle expected = new Rectangle(1184, 320, 320, 48);
+
+//    assertThat(actual).isEqualTo(expected);
+    assertThat(region.x + region.width).isLessThanOrEqualTo(imageSize.width);
+    assertThat(region.y + region.height).isLessThanOrEqualTo(imageSize.height);
   }
 }

--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
@@ -252,7 +252,7 @@ class TurboJpegImageReaderTest {
   }
 
   @Test
-  void testAdjustMCURegion() throws IOException {
+  void testAdjustMCURegion() {
     TurboJpegImageReader reader = new TurboJpegImageReader(null, null);
 
     Dimension mcuSize = new Dimension(16, 16);
@@ -260,11 +260,11 @@ class TurboJpegImageReaderTest {
     int rotation = 0;
     Dimension imageSize = new Dimension(1500, 2260);
 
-    Rectangle actual = reader.adjustRegion(mcuSize, region, rotation, imageSize);
-    Rectangle expected = new Rectangle(1184, 320, 320, 48);
+    Rectangle extraCrop = reader.adjustRegion(mcuSize, region, rotation, imageSize);
+    Rectangle regionExpected = new Rectangle(1184, 320, 316, 48);
+    Rectangle extraCropExpected = new Rectangle(1, 7, 309, 36);
 
-//    assertThat(actual).isEqualTo(expected);
-    assertThat(region.x + region.width).isLessThanOrEqualTo(imageSize.width);
-    assertThat(region.y + region.height).isLessThanOrEqualTo(imageSize.height);
+    assertThat(region).isEqualTo(regionExpected);
+    assertThat(extraCrop).isEqualTo(extraCropExpected);
   }
 }


### PR DESCRIPTION
TurboJpeg expects cropping regions to be multiples of the MCU size. In some cases it was possible that the cropping region was larger than the image due to rounding artifacts (less than one MCU). This MR checks if the resulting region would exceed the image and makes it one MCU width and/or height smaller if needed.

TODO: Is it necessary to adjust the `extraCropping` to make sure it will be inside the adjusted region?