### PR TITLE
Fix use of CMYK for JP2 images

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReader.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReader.java
@@ -118,8 +118,9 @@ public class OpenJp2ImageReader extends ImageReader {
                 OpenJpeg.COLOR_MODEL_CMYK_ALPHA,
                 OpenJpeg.COLOR_MODEL_CMYK_ALPHA.createCompatibleSampleModel(
                     info.getNativeSize().width, info.getNativeSize().height));
+      } else {
+        spec = ImageTypeSpecifier.createFromBufferedImageType(BufferedImage.TYPE_4BYTE_ABGR);
       }
-      spec = ImageTypeSpecifier.createFromBufferedImageType(BufferedImage.TYPE_4BYTE_ABGR);
     } else if (numComps == 1) {
       spec =
           ImageTypeSpecifier.createFromBufferedImageType(


### PR DESCRIPTION
The color scheme has been wrongly set as ARGB for JP2 images using CMYK color space. This MR makes sure CMYK is actually used in these cases.