### PR TITLE
Wrong coordinate calculation when cropping to one pixel height

### DIFF
--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
@@ -212,6 +212,15 @@ class TurboJpegImageReaderTest {
   }
 
   @Test
+  public void testCropToOnePixel() throws IOException {
+    ImageReader reader = getReader("prime_shaped.jpg");
+    TurboJpegImageReadParam param = (TurboJpegImageReadParam) reader.getDefaultReadParam();
+    param.setSourceRegion(new Rectangle(0, 0, reader.getWidth(2), 1));
+    BufferedImage img = reader.read(2, param);
+    assertThat(img).hasDimensions(reader.getWidth(2), 1);
+  }
+
+  @Test
   public void testReadTinyImage() throws IOException {
     ImageReader reader = getReader("tiny.jpg");
     TurboJpegImageReadParam param = (TurboJpegImageReadParam) reader.getDefaultReadParam();

--- a/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
+++ b/imageio-turbojpeg/src/test/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReaderTest.java
@@ -214,10 +214,19 @@ class TurboJpegImageReaderTest {
   @Test
   public void testCropToOnePixel() throws IOException {
     ImageReader reader = getReader("prime_shaped.jpg");
-    TurboJpegImageReadParam param = (TurboJpegImageReadParam) reader.getDefaultReadParam();
-    param.setSourceRegion(new Rectangle(0, 0, reader.getWidth(2), 1));
-    BufferedImage img = reader.read(2, param);
-    assertThat(img).hasDimensions(reader.getWidth(2), 1);
+    TurboJpegImageReadParam scaledParam = (TurboJpegImageReadParam) reader.getDefaultReadParam();
+    scaledParam.setSourceRegion(new Rectangle(0, 0, reader.getWidth(2), 1));
+    BufferedImage img = reader.read(2, scaledParam);
+
+    // Special case (imageIndex > 0), so we have Math.round will return 2 pixel height
+    assertThat(img).hasDimensions(reader.getWidth(2), 2);
+
+    TurboJpegImageReadParam unscaledParam = (TurboJpegImageReadParam) reader.getDefaultReadParam();
+    unscaledParam.setSourceRegion(new Rectangle(0, 0, reader.getWidth(0), 1));
+    BufferedImage newImg = reader.read(0, unscaledParam);
+
+    // In case of imageIndex == 0, we expect a 1 pixel height image
+    assertThat(newImg).hasDimensions(reader.getWidth(0), 1);
   }
 
   @Test


### PR DESCRIPTION
This PR adds one unit test for checking the behaviour of `imageio-jnr` when dealing with one pixel height cropping:

## Sub-tes 1: `imageIndex` greater than zero

When `imageIndex` is greater than zero, a scaled down image is used. After debugging it's shown, that the `adjustExtraCrop` method uses a scaled factor to the the height of cropped region. In that special case, `rectangle.height` is ~1.50 to `Math.round` function will return `2` for the final cropped region. (So this is no bug):

https://github.com/dbmdz/imageio-jnr/blob/fcae1bdec7b50a6375cc53147d75ee74ced845e9/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/imageio/TurboJpegImageReader.java#L246-L264

## Sub-test 2: `imageIndex` is zero

In another (sub-) test we use an `imageIndex` of 0, where the library will correctly return a one pixel height cropped region.