### PR TITLE
Fix crash during JPEG2000 encoding.

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/OpenJpeg.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/OpenJpeg.java
@@ -23,11 +23,13 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
 import jnr.ffi.Struct;
 import jnr.ffi.byref.PointerByReference;
+import jnr.ffi.provider.ParameterFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -424,10 +426,14 @@ public class OpenJpeg {
       params[i].w.set(img.getWidth());
       params[i].h.set(img.getHeight());
     }
+    // We need to keep references to every individual struct, or else we run the risk of them
+    // being deallocated during the call into `opj_image_create`.
+    Pointer[] paramsPtrs = Arrays.stream(params)
+        .map(p -> Struct.getMemory(p, ParameterFlags.DIRECT)).toArray(Pointer[]::new);
 
     COLOR_SPACE cspace = numBands == 3 ? COLOR_SPACE.OPJ_CLRSPC_SRGB : COLOR_SPACE.OPJ_CLRSPC_GRAY;
     opj_image outImg = new opj_image(runtime);
-    Pointer imgPtr = lib.opj_image_create(params.length, Struct.getMemory(params[0]), cspace);
+    Pointer imgPtr = lib.opj_image_create(params.length, paramsPtrs[0], cspace);
     outImg.useMemory(imgPtr);
 
     outImg.x0.set(0);

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/libopenjp2.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/libopenjp2.java
@@ -78,7 +78,7 @@ public interface libopenjp2 {
   boolean opj_encode(Pointer codec, Pointer stream);
 
   /* opj_image functions */
-  Pointer opj_image_create(@u_int32_t int numcmpts, Pointer cmtparms, COLOR_SPACE clrspc);
+  Pointer opj_image_create(@u_int32_t int numcmpts, @Direct Pointer cmtparms, COLOR_SPACE clrspc);
 
   void opj_image_destroy(Pointer image);
 


### PR DESCRIPTION
A misunderstanding in the way JNR-FFI worked led to a hard-to-debug segmentation fault crash when encoding JPEG2000 images concurrently.
The bug was in our call to `opj_image_create` during encoding. This function takes a pointer to an array of `opj_image_comptparm` structs. On the Java side, we allocated those structs through JNR-FFI's `Runtime` and passed the address of the first member of the array to the function. This was done under the assumption that the memory allocated by JNR-FFI for the array members would be the same memory that gets passed over the FFI, and, since we confirmed that JNR-FFI allocates those array members as a single contiguous memory segment, it would be safe to do so.
However, this is based on a significant misunderstanding how passing memory between the JVM and the native code works with JNR-FFI. It seems that when a pointer is passed over the FFI, a copy is created for the memory it is pointing at, and when the function returns, that temporary memory is copied back to the JVM memory.
It seems that only the memory that is backed by a `Pointer` instance on the JVM side is safe from deallocation during the function call.
The solution to the crashes is thus to simply create a pointer for every struct member to make sure it actually gets copied over and is not deallocated at some point.
Open questions remain: Why does the segfault only happen occisaionaly (high concurrency + large images on my dev machine). And why doesn't it happen when we attach a debugger?

This fix also points at a potential avenue for performance improvements: How much unneeded copying is going on that we could skip via `@In`,`@Out` or `@Direct` annotations?