### PR TITLE
Fix jp2 encoding segfault, next attempt

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/OpenJpeg.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/OpenJpeg.java
@@ -23,13 +23,11 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import jnr.ffi.LibraryLoader;
 import jnr.ffi.Pointer;
 import jnr.ffi.Runtime;
 import jnr.ffi.Struct;
 import jnr.ffi.byref.PointerByReference;
-import jnr.ffi.provider.ParameterFlags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -426,14 +424,10 @@ public class OpenJpeg {
       params[i].w.set(img.getWidth());
       params[i].h.set(img.getHeight());
     }
-    // We need to keep references to every individual struct, or else we run the risk of them
-    // being deallocated during the call into `opj_image_create`.
-    Pointer[] paramsPtrs = Arrays.stream(params)
-        .map(p -> Struct.getMemory(p, ParameterFlags.DIRECT)).toArray(Pointer[]::new);
 
     COLOR_SPACE cspace = numBands == 3 ? COLOR_SPACE.OPJ_CLRSPC_SRGB : COLOR_SPACE.OPJ_CLRSPC_GRAY;
     opj_image outImg = new opj_image(runtime);
-    Pointer imgPtr = lib.opj_image_create(params.length, paramsPtrs[0], cspace);
+    Pointer imgPtr = lib.opj_image_create(params.length, Struct.getMemory(params[0]), cspace);
     outImg.useMemory(imgPtr);
 
     outImg.x0.set(0);

--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/libopenjp2.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/lib/libopenjp2.java
@@ -78,7 +78,7 @@ public interface libopenjp2 {
   boolean opj_encode(Pointer codec, Pointer stream);
 
   /* opj_image functions */
-  Pointer opj_image_create(@u_int32_t int numcmpts, @Direct Pointer cmtparms, COLOR_SPACE clrspc);
+  Pointer opj_image_create(@u_int32_t int numcmpts, Pointer cmtparms, COLOR_SPACE clrspc);
 
   void opj_image_destroy(Pointer image);
 


### PR DESCRIPTION
This is another attempt at fixing the bug mentioned in an earlier commit. The previous attempt was already headed in the right direction but didn't actually work.
This next attempt seems to be more promising, at least I couldn't trigger it when hammering my encoding test on 8 threads for ~3h, that would pretty reliably crash previously.

The gory details:
`Struct.arrayOf` allocates a continuous chunk to back an array of structures. JNR's `TransientMemoryAllocator` does not allocate memory directly for small allocations (<=256 bytes), but uses a custom page-based allocation strategy. When allocation for a new page fails, it triggers a full GC cycle and clears up all 'old and unused' pages.
However, there seems to be a bug involving concurrency and garbage collection, that leads to this cleanup process freeing memory that is still in use.
To work around this, we force arrays of structs to be always backed by a memory block of at least 512 bytes, thereby bypassing the transient memory allocator and using JNR's direct memory allocation strategy that follows different rules for freeing unused memory.
