### PR TITLE
readme: mention new 0.6.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ To use the ImageIO plugins, include them in your dependencies:
 <dependency>
   <groupId>de.digitalcollections.imageio</groupId>
   <artifactId>imageio-turbojpeg</artifactId>
-  <version>0.6.5</version>
+  <version>0.6.6</version>
 </dependency>
 
 <dependency>
   <groupId>de.digitalcollections.imageio</groupId>
   <artifactId>imageio-openjpeg</artifactId>
-  <version>0.6.5</version>
+  <version>0.6.6</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Hi,

this PR updates ImageIO version (to 0.6.6) in readme.