### PR TITLE
turbojpeg: Fix JPEG decoding from TIFFs with versions >=2.1.4

### DIFF
--- a/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/lib/libturbojpeg.java
+++ b/imageio-turbojpeg/src/main/java/de/digitalcollections/turbojpeg/lib/libturbojpeg.java
@@ -42,10 +42,10 @@ public interface libturbojpeg {
       Pointer handle,
       Buffer jpegBuf,
       @u_int32_t long jpegSize,
-      @Out IntByReference width,
-      @Out IntByReference height,
-      @Out IntByReference jpegSubsamp,
-      @Out IntByReference jpegColorspace);
+      @Out @In IntByReference width,
+      @Out @In IntByReference height,
+      @Out @In IntByReference jpegSubsamp,
+      @Out @In IntByReference jpegColorspace);
 
   int tjTransform(
       Pointer handle,


### PR DESCRIPTION
turbojpeg introduced support for `abbreviated datastreams` in 2.1.4, returning early from `tjDecompressHeader3` if such a datastream is detected, and thus not updating the values for width, height colorspace and subsampling that we relied on.

This didn't cause issues with the standard ImageIO `TIFFImageReader` from the `com.sun` package, since it always completely decoded the JPEG. However, the TwelveMonkeys implementation was more efficient and only used the abbreviated datastream from the TIFF Header, as intended.

This broke our code, since we assumed that width, height, colorspace and subsampling were always available.

Luckily the fix was rather trivial: Simply check if the values were set tor not and return `null` if they weren't. The `null` info value doesn't cause any issues, since by the time the values are needed, we already have a new input with the full datastream available and will read the info from there.