### PR TITLE
feat(imageio-openjpeg): enable raster read on `OpenJp2ImageReader`

### DIFF
--- a/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReader.java
+++ b/imageio-openjpeg/src/main/java/de/digitalcollections/openjpeg/imageio/OpenJp2ImageReader.java
@@ -5,6 +5,7 @@ import de.digitalcollections.openjpeg.OpenJpeg;
 import de.digitalcollections.openjpeg.lib.enums.COLOR_SPACE;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
+import java.awt.image.Raster;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.stream.Stream;
@@ -226,6 +227,21 @@ public class OpenJp2ImageReader extends ImageReader {
     ImageReadParam param = getDefaultReadParam();
     param.setSourceRegion(region);
     return this.read(imageIndex, param);
+  }
+
+  @Override
+  public boolean canReadRaster() {
+    return true;
+  }
+
+  @Override
+  public Raster readRaster(int imageIndex, ImageReadParam param) throws IOException {
+    return this.read(imageIndex, param).getData();
+  }
+
+  @Override
+  public Raster readTileRaster(int imageIndex, int tileX, int tileY) throws IOException {
+    return this.readTile(imageIndex,tileX,tileY).getData();
   }
 
   @Override


### PR DESCRIPTION
The class now overrides the raster functions from `ImageReader` class. The `canReadRaster` returns true enabling the caller to call `readRaster` and `readTileRaster`.

The readRaster and readTileRaster call the normal read functions and then return the raster with `getData` call on the buffered image.

Test cases are added to compare the rasters on expected and actual images with the option of tolerance in the diff of samples if the quality of images is low.

I have made these changes based on the assumption that openjpeg supports rasters 

Related issue: https://github.com/dbmdz/imageio-jnr/issues/244